### PR TITLE
Migrate ContributesSubcomponentHandlerGenerator to KSP, + more

### DIFF
--- a/annotations/api/annotations.api
+++ b/annotations/api/annotations.api
@@ -134,6 +134,12 @@ public abstract interface annotation class com/squareup/anvil/annotations/compat
 	public abstract fun value ()[Lcom/squareup/anvil/annotations/compat/MergeModules;
 }
 
+public abstract interface annotation class com/squareup/anvil/annotations/internal/GeneratedMergeableSubcomponent : java/lang/annotation/Annotation {
+	public abstract fun componentFactory ()Ljava/lang/Class;
+	public abstract fun contributor ()Ljava/lang/Class;
+	public abstract fun root ()Ljava/lang/Class;
+}
+
 public abstract interface annotation class com/squareup/anvil/annotations/internal/InternalBindingMarker : java/lang/annotation/Annotation {
 	public abstract fun isMultibinding ()Z
 	public abstract fun originClass ()Ljava/lang/Class;

--- a/annotations/api/annotations.api
+++ b/annotations/api/annotations.api
@@ -134,12 +134,6 @@ public abstract interface annotation class com/squareup/anvil/annotations/compat
 	public abstract fun value ()[Lcom/squareup/anvil/annotations/compat/MergeModules;
 }
 
-public abstract interface annotation class com/squareup/anvil/annotations/internal/GeneratedMergeableSubcomponent : java/lang/annotation/Annotation {
-	public abstract fun componentFactory ()Ljava/lang/Class;
-	public abstract fun contributor ()Ljava/lang/Class;
-	public abstract fun root ()Ljava/lang/Class;
-}
-
 public abstract interface annotation class com/squareup/anvil/annotations/internal/InternalBindingMarker : java/lang/annotation/Annotation {
 	public abstract fun isMultibinding ()Z
 	public abstract fun originClass ()Ljava/lang/Class;
@@ -149,5 +143,16 @@ public abstract interface annotation class com/squareup/anvil/annotations/intern
 
 public abstract interface annotation class com/squareup/anvil/annotations/internal/InternalBindingMarker$Container : java/lang/annotation/Annotation {
 	public abstract fun value ()[Lcom/squareup/anvil/annotations/internal/InternalBindingMarker;
+}
+
+public abstract interface annotation class com/squareup/anvil/annotations/internal/InternalContributedSubcomponentMarker : java/lang/annotation/Annotation {
+	public abstract fun componentFactory ()Ljava/lang/Class;
+	public abstract fun contributor ()Ljava/lang/Class;
+	public abstract fun originClass ()Ljava/lang/Class;
+}
+
+public abstract interface annotation class com/squareup/anvil/annotations/internal/InternalMergedTypeMarker : java/lang/annotation/Annotation {
+	public abstract fun originClass ()Ljava/lang/Class;
+	public abstract fun scope ()Ljava/lang/Class;
 }
 

--- a/annotations/src/main/java/com/squareup/anvil/annotations/internal/InternalContributedSubcomponentMarker.kt
+++ b/annotations/src/main/java/com/squareup/anvil/annotations/internal/InternalContributedSubcomponentMarker.kt
@@ -1,7 +1,7 @@
 package com.squareup.anvil.annotations.internal
 
-import kotlin.reflect.KClass
 import com.squareup.anvil.annotations.ContributesSubcomponent
+import kotlin.reflect.KClass
 
 /**
  * When using [ContributesSubcomponent], we generate some extra information based on the source

--- a/annotations/src/main/java/com/squareup/anvil/annotations/internal/InternalContributedSubcomponentMarker.kt
+++ b/annotations/src/main/java/com/squareup/anvil/annotations/internal/InternalContributedSubcomponentMarker.kt
@@ -1,0 +1,122 @@
+package com.squareup.anvil.annotations.internal
+
+import kotlin.reflect.KClass
+import com.squareup.anvil.annotations.ContributesSubcomponent
+
+/**
+ * When using [ContributesSubcomponent], we generate some extra information based on the source
+ * class.
+ *
+ * There are two types of contribution supported.
+ *
+ * ## Factory
+ *
+ * ```kotlin
+ * @ContributesSubcomponent(UserScope::class, parentScope = AppScope::class)
+ * interface UserComponent {
+ *   @ContributesSubcomponent.Factory
+ *   interface ComponentFactory {
+ *     fun createComponent(
+ *       @BindsInstance integer: Int
+ *     ): UserComponent
+ *   }
+ *
+ *   fun integer(): Int
+ * }
+ * ```
+ *
+ * In this case, [componentFactory] will be set to the `ComponentFactory` interface. This in turn
+ * will generate code like so.
+ *
+ * ```kotlin
+ * // Intermediate merge class
+ * @InternalContributedSubcomponentMarker(
+ *   originClass = UserComponent::class,
+ *   componentFactory = UserComponent.ComponentFactory::class
+ * )
+ * @MergeSubcomponent(scope = Any::class)
+ * interface UserComponent_0536E4Be : UserComponent
+ *
+ * // Final merged classes
+ * @Subcomponent(includes = [MergedUserComponent_0536E4Be.BindingModule::class])
+ * interface MergedUserComponent_0536E4Be : UserComponent_0536E4Be {
+ *   @Module
+ *   interface BindingModule {
+ *     @Binds
+ *     fun bindComponent(impl: MergedUserComponent_0536E4Be): UserComponent
+ *   }
+ *
+ *   @Module
+ *   interface SubcomponentModule {
+ *     @Binds
+ *     fun bindComponentFactory(impl: ComponentFactory): UserComponent.ComponentFactory
+ *   }
+ *
+ *   @Subcomponent.Factory
+ *   interface ComponentFactory : UserComponent.ComponentFactory {
+ *     override fun createComponent(@BindsInstance integer: Int): MergedUserComponent_0536E4Be
+ *   }
+ *
+ *   interface ParentComponent {
+ *     fun createComponentFactory(): ComponentFactory
+ *   }
+ * }
+ *
+ * @Component(modules = [MergedUserComponent_0536E4Be.SubcomponentModule::class])
+ * interface MergedAppComponent : AppComponent, MergedUserComponent_0536E4Be.ParentComponent {
+ *   @Component.Factory
+ *   fun interface AppComponentFactory : AppComponent.Factory {
+ *     override fun create(): MergedAppComponent
+ *   }
+ * }
+ * ```
+ *
+ * ## Contributed Parent Component
+ *
+ * ```kotlin
+ * @ContributesSubcomponent(UserScope::class, parentScope = AppScope::class)
+ * interface UserComponent {
+ *   @ContributesTo(AppScope::class)
+ *   interface UserScopeParentComponent {
+ *     fun createComponent(): UserComponent
+ *   }
+ * }
+ * ```
+ * In this case, [contributor] will be set to the `UserScopeParentComponent` interface. This in turn
+ * will generate code like so.
+ *
+ * ```kotlin
+ * // Intermediate merge class
+ * @MergeSubcomponent(scope = Any::class)
+ * interface UserComponent_0536E4Be : UserComponent
+ *
+ * // Final merged classes
+ * @InternalContributedSubcomponentMarker(
+ *   originClass = UserComponent::class,
+ *   contributor = UserComponent.UserScopeParentComponent::class
+ * )
+ * @Subcomponent(modules = [MergedUserComponent_0536E4Be.BindingModule::class])
+ * interface MergedUserComponent_0536E4Be : UserComponent_0536E4Be {
+ *   @Module
+ *   interface BindingModule {
+ *     @Binds
+ *     fun bindComponent(impl: MergedUserComponent_0536E4Be): UserComponent
+ *   }
+ *
+ *   interface ParentComponent : UserComponent.UserScopeParentComponent {
+ *     override fun createComponent(): MergedUserComponent_0536E4Be
+ *   }
+ * }
+ *
+ * @Component
+ * interface MergedAppComponent : AppComponent,
+ *   UserComponent.UserScopeParentComponent,
+ *   MergedUserComponent_0536E4Be.ParentComponent
+ * ```
+ */
+@Target(AnnotationTarget.CLASS)
+public annotation class InternalContributedSubcomponentMarker(
+  val originClass: KClass<*>,
+  val contributor: KClass<*> = Nothing::class,
+  val componentFactory: KClass<*> = Nothing::class,
+)

--- a/annotations/src/main/java/com/squareup/anvil/annotations/internal/InternalMergedTypeMarker.kt
+++ b/annotations/src/main/java/com/squareup/anvil/annotations/internal/InternalMergedTypeMarker.kt
@@ -1,0 +1,12 @@
+package com.squareup.anvil.annotations.internal
+
+import kotlin.reflect.KClass
+
+/**
+ * Metadata bout the origin of a merged type. Useful for testing and can be discarded in production.
+ */
+@Target(AnnotationTarget.CLASS)
+public annotation class InternalMergedTypeMarker(
+  val originClass: KClass<*>,
+  val scope: KClass<*>,
+)

--- a/compiler-utils/src/testFixtures/java/com/squareup/anvil/compiler/internal/testing/AnvilCompilation.kt
+++ b/compiler-utils/src/testFixtures/java/com/squareup/anvil/compiler/internal/testing/AnvilCompilation.kt
@@ -42,7 +42,11 @@ public class AnvilCompilation internal constructor(
   @ExperimentalAnvilApi
   public fun configureAnvil(
     componentProcessingMode: ComponentProcessingMode = ComponentProcessingMode.NONE,
-    componentMergingBackend: ComponentMergingBackend = ComponentMergingBackend.IR,
+    componentMergingBackend: ComponentMergingBackend = if (componentProcessingMode == ComponentProcessingMode.KSP) {
+      ComponentMergingBackend.KSP
+    } else {
+      ComponentMergingBackend.IR
+    },
     generateDaggerFactories: Boolean = false,
     generateDaggerFactoriesOnly: Boolean = false,
     disableComponentMerging: Boolean = false,
@@ -323,7 +327,11 @@ public enum class ComponentProcessingMode {
 public fun compileAnvil(
   @Language("kotlin") vararg sources: String,
   componentProcessingMode: ComponentProcessingMode = ComponentProcessingMode.NONE,
-  componentMergingBackend: ComponentMergingBackend = ComponentMergingBackend.IR,
+  componentMergingBackend: ComponentMergingBackend = if (componentProcessingMode == ComponentProcessingMode.KSP) {
+    ComponentMergingBackend.KSP
+  } else {
+    ComponentMergingBackend.IR
+  },
   generateDaggerFactories: Boolean = false,
   generateDaggerFactoriesOnly: Boolean = false,
   disableComponentMerging: Boolean = false,

--- a/compiler-utils/src/testFixtures/java/com/squareup/anvil/compiler/internal/testing/AnyDaggerComponent.kt
+++ b/compiler-utils/src/testFixtures/java/com/squareup/anvil/compiler/internal/testing/AnyDaggerComponent.kt
@@ -4,6 +4,7 @@ import com.squareup.anvil.annotations.ExperimentalAnvilApi
 import com.squareup.anvil.annotations.MergeComponent
 import com.squareup.anvil.annotations.MergeSubcomponent
 import com.squareup.anvil.annotations.compat.MergeModules
+import com.squareup.anvil.annotations.internal.InternalMergedTypeMarker
 import com.squareup.anvil.compiler.internal.mergedClassName
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.DelicateKotlinPoetApi
@@ -62,4 +63,20 @@ public fun Class<*>.generatedMergedComponentOrNull(): Class<*>? {
   } catch (e: ClassNotFoundException) {
     null
   }
+}
+
+/**
+ * The inverse of [resolveIfMerged], returning the original root type if this class is a merged
+ * component.
+ */
+@ExperimentalAnvilApi
+public fun Class<*>.originIfMerged(): Class<*> = originOfMergedComponentOrNull() ?: this
+
+/**
+ * The inverse of [generatedMergedComponentOrNull], returning the original root type if this class
+ * is a merged component.
+ */
+@ExperimentalAnvilApi
+public fun Class<*>.originOfMergedComponentOrNull(): Class<*>? {
+  return getDeclaredAnnotation(InternalMergedTypeMarker::class.java)?.originClass?.java
 }

--- a/compiler-utils/src/testFixtures/java/com/squareup/anvil/compiler/internal/testing/TestUtils.kt
+++ b/compiler-utils/src/testFixtures/java/com/squareup/anvil/compiler/internal/testing/TestUtils.kt
@@ -156,13 +156,13 @@ public fun Collection<KClass<*>>.withoutAnvilModules(): List<KClass<*>> =
 @ExperimentalAnvilApi
 public fun Collection<KClass<*>>.withoutMergedBindingModules(): List<KClass<*>> =
   filterNot {
-      it.java.isMergedBindingModule()
+    it.java.isMergedBindingModule()
   }
 
 @ExperimentalAnvilApi
 public fun Array<KClass<*>>.withoutMergedBindingModules(): Array<KClass<*>> =
   filterNot {
-      it.java.isMergedBindingModule()
+    it.java.isMergedBindingModule()
   }.toTypedArray()
 
 /**

--- a/compiler-utils/src/testFixtures/java/com/squareup/anvil/compiler/internal/testing/TestUtils.kt
+++ b/compiler-utils/src/testFixtures/java/com/squareup/anvil/compiler/internal/testing/TestUtils.kt
@@ -6,6 +6,7 @@ import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.Truth.assertWithMessage
 import com.squareup.anvil.annotations.ExperimentalAnvilApi
 import com.squareup.anvil.annotations.internal.InternalBindingMarker
+import com.squareup.anvil.annotations.internal.InternalMergedTypeMarker
 import com.squareup.anvil.compiler.internal.capitalize
 import dagger.Component
 import dagger.Module
@@ -147,10 +148,28 @@ public fun Array<KClass<*>>.withoutAnvilModules(): List<KClass<*>> = toList().wi
 @ExperimentalAnvilApi
 public fun Collection<KClass<*>>.withoutAnvilModules(): List<KClass<*>> =
   filterNot {
-    it.qualifiedName!!.startsWith("anvil.module") || it.java.isAnnotationPresent(
-      InternalBindingMarker::class.java,
-    )
+    it.qualifiedName!!.startsWith("anvil.module") ||
+      it.java.isAnnotationPresent(InternalBindingMarker::class.java)
   }
+    .withoutMergedBindingModules()
+
+@ExperimentalAnvilApi
+public fun Collection<KClass<*>>.withoutMergedBindingModules(): List<KClass<*>> =
+  filterNot {
+      it.java.isMergedBindingModule()
+  }
+
+@ExperimentalAnvilApi
+public fun Array<KClass<*>>.withoutMergedBindingModules(): Array<KClass<*>> =
+  filterNot {
+      it.java.isMergedBindingModule()
+  }.toTypedArray()
+
+/**
+ * Returns true if this is a Merged* class's associated binding module.
+ */
+@ExperimentalAnvilApi
+public fun Class<*>.isMergedBindingModule(): Boolean = isAnnotationPresent(Module::class.java) && simpleName == "BindingModule" && enclosingClass?.isAnnotationPresent(InternalMergedTypeMarker::class.java) == true
 
 @ExperimentalAnvilApi
 public fun Any.invokeGet(vararg args: Any?): Any {

--- a/compiler/src/main/java/com/squareup/anvil/compiler/BindingModuleSpecs.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/BindingModuleSpecs.kt
@@ -24,7 +24,7 @@ internal data class BindingSpec(
  */
 internal fun daggerBindingModuleSpec(
   moduleName: String,
-  specs: Collection<BindingSpec>
+  specs: Collection<BindingSpec>,
 ): TypeSpec {
   check(specs.isNotEmpty())
   return TypeSpec

--- a/compiler/src/main/java/com/squareup/anvil/compiler/BindingModuleSpecs.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/BindingModuleSpecs.kt
@@ -1,0 +1,47 @@
+package com.squareup.anvil.compiler
+
+import com.squareup.anvil.compiler.internal.capitalize
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.KModifier.ABSTRACT
+import com.squareup.kotlinpoet.TypeSpec
+import dagger.Binds
+import dagger.Module
+
+/**
+ * A binding spec for use with [daggerBindingModuleSpec].
+ */
+internal data class BindingSpec(
+  val impl: ClassName,
+  val boundType: ClassName,
+  val functionName: String = "bind${impl.simpleName.capitalize()}",
+)
+
+/**
+ * A [TypeSpec] factory for a Dagger binding module.
+ *
+ * @param specs a collection of [BindingSpec]s to generate binding functions for.
+ */
+internal fun daggerBindingModuleSpec(
+  moduleName: String,
+  specs: Collection<BindingSpec>
+): TypeSpec {
+  check(specs.isNotEmpty())
+  return TypeSpec
+    .interfaceBuilder(moduleName)
+    .addAnnotation(Module::class)
+    .apply {
+      for (spec in specs) {
+        addFunction(
+          FunSpec
+            .builder(spec.functionName)
+            .addAnnotation(Binds::class)
+            .addModifiers(ABSTRACT)
+            .addParameter("impl", spec.impl)
+            .returns(spec.boundType)
+            .build(),
+        )
+      }
+    }
+    .build()
+}

--- a/compiler/src/main/java/com/squareup/anvil/compiler/ClassScanningKspProcessor.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/ClassScanningKspProcessor.kt
@@ -32,7 +32,8 @@ internal class ClassScanningKspProcessor(
       val context = env.toAnvilContext()
       // Shared caching class scanner for both processors
       val classScanner = ClassScannerKsp()
-      val contributesSubcomponentHandler = KspContributesSubcomponentHandlerSymbolProcessor(env, classScanner)
+      val contributesSubcomponentHandler =
+        KspContributesSubcomponentHandlerSymbolProcessor(env, classScanner)
       val componentMergingEnabled = !context.disableComponentMerging && !context.generateFactories && context.componentMergingBackend == ComponentMergingBackend.KSP
       val delegate = if (componentMergingEnabled) {
         // We're running component merging, so we need to run both and let KspContributionMerger

--- a/compiler/src/main/java/com/squareup/anvil/compiler/ClassScanningKspProcessor.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/ClassScanningKspProcessor.kt
@@ -1,0 +1,58 @@
+package com.squareup.anvil.compiler
+
+import com.google.auto.service.AutoService
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
+import com.google.devtools.ksp.processing.SymbolProcessorProvider
+import com.squareup.anvil.compiler.api.ComponentMergingBackend
+import com.squareup.anvil.compiler.codegen.KspContributesSubcomponentHandlerSymbolProcessor
+import com.squareup.anvil.compiler.codegen.ksp.AnvilSymbolProcessor
+import com.squareup.anvil.compiler.codegen.ksp.AnvilSymbolProcessorProvider
+import com.squareup.anvil.compiler.codegen.toAnvilContext
+
+/**
+ * An abstraction layer between [KspContributesSubcomponentHandlerSymbolProcessor] and [KspContributionMerger]
+ * to handle running them contextually and with a shared caching [ClassScannerKsp].
+ *
+ * @see Provider for more details on the logic of when each are used.
+ */
+internal class ClassScanningKspProcessor(
+  override val env: SymbolProcessorEnvironment,
+  private val delegate: SymbolProcessor,
+) : AnvilSymbolProcessor() {
+
+  @AutoService(SymbolProcessorProvider::class)
+  class Provider : AnvilSymbolProcessorProvider(
+    { context ->
+      // Both qualify to run if we're not only generating factories
+      !context.generateFactoriesOnly
+    },
+    { env ->
+      val context = env.toAnvilContext()
+      // Shared caching class scanner for both processors
+      val classScanner = ClassScannerKsp()
+      val contributesSubcomponentHandler = KspContributesSubcomponentHandlerSymbolProcessor(env, classScanner)
+      val componentMergingEnabled = !context.disableComponentMerging && !context.generateFactories && context.componentMergingBackend == ComponentMergingBackend.KSP
+      val delegate = if (componentMergingEnabled) {
+        // We're running component merging, so we need to run both and let KspContributionMerger
+        // handle running the contributesSubcomponentHandler when needed.
+        KspContributionMerger(env, classScanner, contributesSubcomponentHandler)
+      } else {
+        // We're only generating factories/contributessubcomponents, so only run it.
+        contributesSubcomponentHandler
+      }
+      ClassScanningKspProcessor(env, delegate)
+    },
+  )
+
+  override fun processChecked(resolver: Resolver) = delegate.process(resolver)
+
+  override fun finish() {
+    delegate.finish()
+  }
+
+  override fun onError() {
+    delegate.onError()
+  }
+}

--- a/compiler/src/main/java/com/squareup/anvil/compiler/KspContributionMerger.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/KspContributionMerger.kt
@@ -1200,7 +1200,7 @@ private fun Creator.extend(
     .addAnnotations(
       declaration.annotations.map(KSAnnotation::toAnnotationSpec)
         .filterNot { it.typeName == contributesSubcomponentFactoryClassName }
-        .asIterable()
+        .asIterable(),
     )
     .apply {
       for (function in declaration.getDeclaredFunctions()) {

--- a/compiler/src/main/java/com/squareup/anvil/compiler/KspContributionMerger.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/KspContributionMerger.kt
@@ -1197,7 +1197,11 @@ private fun Creator.extend(
    }
    */
   val creatorSpec = builder
-    .addAnnotations(declaration.annotations.map(KSAnnotation::toAnnotationSpec).asIterable())
+    .addAnnotations(
+      declaration.annotations.map(KSAnnotation::toAnnotationSpec)
+        .filterNot { it.typeName == contributesSubcomponentFactoryClassName }
+        .asIterable()
+    )
     .apply {
       for (function in declaration.getDeclaredFunctions()) {
         // Only add the function we need to override and update the type

--- a/compiler/src/main/java/com/squareup/anvil/compiler/KspContributionMerger.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/KspContributionMerger.kt
@@ -164,7 +164,8 @@ internal class KspContributionMerger(
       mergeInterfacesFqName,
     ).filterIsInstance<KSClassDeclaration>()
       .validate { deferred ->
-        return deferred }
+        return deferred
+      }
       .also { mergeAnnotatedTypes ->
         if (shouldDefer) {
           return mergeAnnotatedTypes
@@ -788,7 +789,7 @@ internal class KspContributionMerger(
           AnnotationSpec.builder(InternalMergedTypeMarker::class)
             .addMember("originClass = %T::class", mergeAnnotatedClassName)
             .addMember("scope = %T::class", scope)
-            .build()
+            .build(),
         )
         if (!isModule) {
           addSuperinterface(mergeAnnotatedClassName)
@@ -834,7 +835,7 @@ internal class KspContributionMerger(
           addType(
             generateDaggerBindingModuleForFactory(
               parent = creator.declaration,
-              impl = generatedComponentClassName.nestedClass(creatorSpec.name!!)
+              impl = generatedComponentClassName.nestedClass(creatorSpec.name!!),
             ),
           )
 
@@ -1433,7 +1434,9 @@ internal sealed interface Creator {
               }.factory()",
             )
             .build()
-        } else null
+        } else {
+          null
+        }
         Factory(
           declaration = declaration,
           daggerFunSpec = daggerFunSpec,
@@ -1453,7 +1456,9 @@ internal sealed interface Creator {
               }.builder()",
             )
             .build()
-        } else null
+        } else {
+          null
+        }
         Builder(
           declaration = declaration,
           daggerFunSpec = daggerFunSpec,
@@ -1468,7 +1473,7 @@ internal sealed interface Creator {
 // TODO dedupe logic with ContributesSubcomponentHandler version?
 private fun generateDaggerBindingModuleForFactory(
   parent: KSClassDeclaration,
-  impl: ClassName
+  impl: ClassName,
 ): TypeSpec {
   // This Dagger module will allow injecting the factory instance.
   return TypeSpec

--- a/compiler/src/main/java/com/squareup/anvil/compiler/Utils.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/Utils.kt
@@ -47,6 +47,7 @@ internal val contributesBindingFqName = ContributesBinding::class.fqName
 internal val contributesMultibindingFqName = ContributesMultibinding::class.fqName
 internal val contributesSubcomponentFqName = ContributesSubcomponent::class.fqName
 internal val contributesSubcomponentFactoryFqName = ContributesSubcomponent.Factory::class.fqName
+internal val contributesSubcomponentFactoryClassName = ContributesSubcomponent.Factory::class.asClassName()
 internal val internalBindingMarkerFqName = InternalBindingMarker::class.fqName
 internal val daggerComponentFqName = Component::class.fqName
 internal val daggerComponentFactoryFqName = Component.Factory::class.fqName

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGenerator.kt
@@ -1,7 +1,6 @@
 package com.squareup.anvil.compiler.codegen
 
 import com.squareup.anvil.annotations.MergeSubcomponent
-import com.squareup.anvil.compiler.COMPONENT_PACKAGE_PREFIX
 import com.squareup.anvil.compiler.ClassScanner
 import com.squareup.anvil.compiler.PARENT_COMPONENT
 import com.squareup.anvil.compiler.SUBCOMPONENT_FACTORY
@@ -14,16 +13,13 @@ import com.squareup.anvil.compiler.contributesSubcomponentFqName
 import com.squareup.anvil.compiler.contributesToFqName
 import com.squareup.anvil.compiler.internal.asClassName
 import com.squareup.anvil.compiler.internal.buildFile
-import com.squareup.anvil.compiler.internal.joinSimpleNamesAndTruncate
 import com.squareup.anvil.compiler.internal.reference.AnnotationReference
 import com.squareup.anvil.compiler.internal.reference.AnvilCompilationExceptionClassReference
 import com.squareup.anvil.compiler.internal.reference.ClassReference
 import com.squareup.anvil.compiler.internal.reference.MemberFunctionReference
 import com.squareup.anvil.compiler.internal.reference.Visibility.PUBLIC
-import com.squareup.anvil.compiler.internal.reference.asClassId
 import com.squareup.anvil.compiler.internal.reference.asClassName
 import com.squareup.anvil.compiler.internal.reference.classAndInnerClassReferences
-import com.squareup.anvil.compiler.internal.safePackageString
 import com.squareup.anvil.compiler.mergeComponentFqName
 import com.squareup.anvil.compiler.mergeInterfacesFqName
 import com.squareup.anvil.compiler.mergeSubcomponentFqName

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/KspContributesSubcomponentHandlerSymbolProcessor.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/KspContributesSubcomponentHandlerSymbolProcessor.kt
@@ -157,7 +157,8 @@ internal class KspContributesSubcomponentHandlerSymbolProcessor(
             )
             .apply {
               env.logger.info("Writing `@MergeSubcomponent` type ${contribution.clazz.fqName}")
-              val parentComponentInterface = findParentComponentInterface(contribution, factoryClass?.originalReference)
+              val parentComponentInterface =
+                findParentComponentInterface(contribution, factoryClass?.originalReference)
               addAnnotation(
                 AnnotationSpec.builder(InternalContributedSubcomponentMarker::class)
                   .addMember("originClass = %T::class", contributionClassName)
@@ -175,17 +176,19 @@ internal class KspContributesSubcomponentHandlerSymbolProcessor(
                   .build(),
               )
 
-              addType(daggerBindingModuleSpec(
-                BINDING_MODULE_SUFFIX,
-                listOf(BindingSpec(impl = generatedClassName, boundType = contributionClassName))
-              ))
+              addType(
+                daggerBindingModuleSpec(
+                  BINDING_MODULE_SUFFIX,
+                  listOf(BindingSpec(impl = generatedClassName, boundType = contributionClassName)),
+                ),
+              )
 
               if (parentComponentInterface == null) {
                 addType(
                   generateParentComponent(
                     origin = contributionClassName,
                     factoryClass = factoryClass,
-                  )
+                  ),
                 )
               }
             }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/KspContributesSubcomponentHandlerSymbolProcessor.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/KspContributesSubcomponentHandlerSymbolProcessor.kt
@@ -15,14 +15,10 @@ import com.google.devtools.ksp.symbol.Visibility
 import com.google.devtools.ksp.symbol.impl.hasAnnotation
 import com.squareup.anvil.annotations.MergeSubcomponent
 import com.squareup.anvil.compiler.COMPONENT_PACKAGE_PREFIX
-import com.squareup.anvil.compiler.ClassScanner
 import com.squareup.anvil.compiler.ClassScannerKsp
 import com.squareup.anvil.compiler.PARENT_COMPONENT
 import com.squareup.anvil.compiler.SUBCOMPONENT_FACTORY
 import com.squareup.anvil.compiler.SUBCOMPONENT_MODULE
-import com.squareup.anvil.compiler.api.AnvilContext
-import com.squareup.anvil.compiler.api.GeneratedFileWithSources
-import com.squareup.anvil.compiler.api.createGeneratedFile
 import com.squareup.anvil.compiler.codegen.ksp.AnvilSymbolProcessor
 import com.squareup.anvil.compiler.codegen.ksp.AnvilSymbolProcessorProvider
 import com.squareup.anvil.compiler.codegen.ksp.KspAnvilException
@@ -34,7 +30,6 @@ import com.squareup.anvil.compiler.codegen.ksp.fqName
 import com.squareup.anvil.compiler.codegen.ksp.getSymbolsWithAnnotations
 import com.squareup.anvil.compiler.codegen.ksp.isDaggerScope
 import com.squareup.anvil.compiler.codegen.ksp.isInterface
-import com.squareup.anvil.compiler.codegen.ksp.isQualifier
 import com.squareup.anvil.compiler.codegen.ksp.modules
 import com.squareup.anvil.compiler.codegen.ksp.parentScope
 import com.squareup.anvil.compiler.codegen.ksp.replaces
@@ -45,17 +40,9 @@ import com.squareup.anvil.compiler.contributesSubcomponentFactoryFqName
 import com.squareup.anvil.compiler.contributesSubcomponentFqName
 import com.squareup.anvil.compiler.contributesToFqName
 import com.squareup.anvil.compiler.internal.asClassName
-import com.squareup.anvil.compiler.internal.buildFile
 import com.squareup.anvil.compiler.internal.createAnvilSpec
 import com.squareup.anvil.compiler.internal.joinSimpleNamesAndTruncate
-import com.squareup.anvil.compiler.internal.reference.AnnotationReference
-import com.squareup.anvil.compiler.internal.reference.AnvilCompilationExceptionClassReference
-import com.squareup.anvil.compiler.internal.reference.ClassReference
-import com.squareup.anvil.compiler.internal.reference.MemberFunctionReference
-import com.squareup.anvil.compiler.internal.reference.Visibility.PUBLIC
 import com.squareup.anvil.compiler.internal.reference.asClassId
-import com.squareup.anvil.compiler.internal.reference.asClassName
-import com.squareup.anvil.compiler.internal.reference.classAndInnerClassReferences
 import com.squareup.anvil.compiler.internal.safePackageString
 import com.squareup.anvil.compiler.mergeComponentFqName
 import com.squareup.anvil.compiler.mergeInterfacesFqName
@@ -70,16 +57,11 @@ import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.ksp.addOriginatingKSFile
 import com.squareup.kotlinpoet.ksp.toAnnotationSpec
 import com.squareup.kotlinpoet.ksp.toClassName
-import com.squareup.kotlinpoet.ksp.toTypeName
 import com.squareup.kotlinpoet.ksp.writeTo
 import dagger.Binds
 import dagger.Module
-import dagger.Subcomponent
-import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.Name
-import org.jetbrains.kotlin.psi.KtFile
-import java.io.File
 
 /**
  * Looks for `@MergeComponent`, `@MergeSubcomponent` or `@MergeModules` annotations and generates
@@ -209,6 +191,8 @@ internal class KspContributesSubcomponentHandlerSymbolProcessor(
                 .asIterable()
             )
             .apply {
+              // TODO if there's contributed interfaces, need to generate bindings
+              //  i.e. bind SubcomponentInterface2_5a3cef1f as SubcomponentInterface2
               if (factoryClass != null) {
                 addType(generateFactory(factoryClass.originalReference))
                 addType(generateDaggerModule(factoryClass.originalReference))
@@ -249,7 +233,8 @@ internal class KspContributesSubcomponentHandlerSymbolProcessor(
     }
 
     return builder
-      .addAnnotation(Subcomponent.Factory::class)
+      // TODO dagger doesn't like this in our new KSP world
+      // .addAnnotation(Subcomponent.Factory::class)
       .build()
   }
 

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/KspContributesSubcomponentHandlerSymbolProcessor.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/KspContributesSubcomponentHandlerSymbolProcessor.kt
@@ -130,7 +130,7 @@ internal class KspContributesSubcomponentHandlerSymbolProcessor(
         .filterIsInstance<KSClassDeclaration>()
         .map { annotatedClass ->
           val annotation = annotatedClass.find(generationTrigger.asString()).single()
-          Trigger(annotatedClass, annotation.scope(), annotation.exclude())
+          Trigger(annotatedClass, annotation.scope(), annotation.exclude().toSet())
         }
     }
 
@@ -471,7 +471,7 @@ internal class KspContributesSubcomponentHandlerSymbolProcessor(
   private class Trigger(
     val clazz: KSClassDeclaration,
     val scope: KSType,
-    val exclusions: List<KSClassDeclaration>,
+    val exclusions: Set<KSClassDeclaration>,
   ) {
 
     val clazzFqName = clazz.fqName

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/KspContributesSubcomponentHandlerSymbolProcessor.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/KspContributesSubcomponentHandlerSymbolProcessor.kt
@@ -502,10 +502,10 @@ internal class KspContributesSubcomponentHandlerSymbolProcessor(
   private class Contribution(val annotation: KSAnnotation) {
     val clazz = annotation.declaringClass
     val scope = annotation.scope()
-    val parentScope = annotation.parentScope()
+    val parentScopeType = annotation.parentScope().asType(emptyList())
 
     override fun toString(): String {
-      return "Contribution(class=$clazz, scope=$scope, parentScope=$parentScope)"
+      return "Contribution(class=$clazz, scope=$scope, parentScope=$parentScopeType)"
     }
 
     override fun equals(other: Any?): Boolean {
@@ -515,7 +515,7 @@ internal class KspContributesSubcomponentHandlerSymbolProcessor(
       other as Contribution
 
       if (scope != other.scope) return false
-      if (parentScope != other.parentScope) return false
+      if (parentScopeType != other.parentScopeType) return false
       if (clazz != other.clazz) return false
 
       return true
@@ -523,7 +523,7 @@ internal class KspContributesSubcomponentHandlerSymbolProcessor(
 
     override fun hashCode(): Int {
       var result = scope.hashCode()
-      result = 31 * result + parentScope.hashCode()
+      result = 31 * result + parentScopeType.hashCode()
       result = 31 * result + clazz.hashCode()
       return result
     }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/KspContributesSubcomponentHandlerSymbolProcessor.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/KspContributesSubcomponentHandlerSymbolProcessor.kt
@@ -1,19 +1,52 @@
 package com.squareup.anvil.compiler.codegen
 
+import com.google.auto.service.AutoService
+import com.google.devtools.ksp.getVisibility
+import com.google.devtools.ksp.isAbstract
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
+import com.google.devtools.ksp.processing.SymbolProcessorProvider
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSAnnotation
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import com.google.devtools.ksp.symbol.KSType
+import com.google.devtools.ksp.symbol.Visibility
+import com.google.devtools.ksp.symbol.impl.hasAnnotation
 import com.squareup.anvil.annotations.MergeSubcomponent
 import com.squareup.anvil.compiler.COMPONENT_PACKAGE_PREFIX
 import com.squareup.anvil.compiler.ClassScanner
+import com.squareup.anvil.compiler.ClassScannerKsp
 import com.squareup.anvil.compiler.PARENT_COMPONENT
 import com.squareup.anvil.compiler.SUBCOMPONENT_FACTORY
 import com.squareup.anvil.compiler.SUBCOMPONENT_MODULE
 import com.squareup.anvil.compiler.api.AnvilContext
 import com.squareup.anvil.compiler.api.GeneratedFileWithSources
 import com.squareup.anvil.compiler.api.createGeneratedFile
+import com.squareup.anvil.compiler.codegen.ksp.AnvilSymbolProcessor
+import com.squareup.anvil.compiler.codegen.ksp.AnvilSymbolProcessorProvider
+import com.squareup.anvil.compiler.codegen.ksp.KspAnvilException
+import com.squareup.anvil.compiler.codegen.ksp.classId
+import com.squareup.anvil.compiler.codegen.ksp.declaringClass
+import com.squareup.anvil.compiler.codegen.ksp.exclude
+import com.squareup.anvil.compiler.codegen.ksp.find
+import com.squareup.anvil.compiler.codegen.ksp.fqName
+import com.squareup.anvil.compiler.codegen.ksp.getSymbolsWithAnnotations
+import com.squareup.anvil.compiler.codegen.ksp.isDaggerScope
+import com.squareup.anvil.compiler.codegen.ksp.isInterface
+import com.squareup.anvil.compiler.codegen.ksp.isQualifier
+import com.squareup.anvil.compiler.codegen.ksp.modules
+import com.squareup.anvil.compiler.codegen.ksp.parentScope
+import com.squareup.anvil.compiler.codegen.ksp.replaces
+import com.squareup.anvil.compiler.codegen.ksp.resolveKSClassDeclaration
+import com.squareup.anvil.compiler.codegen.ksp.returnTypeOrNull
+import com.squareup.anvil.compiler.codegen.ksp.scope
 import com.squareup.anvil.compiler.contributesSubcomponentFactoryFqName
 import com.squareup.anvil.compiler.contributesSubcomponentFqName
 import com.squareup.anvil.compiler.contributesToFqName
 import com.squareup.anvil.compiler.internal.asClassName
 import com.squareup.anvil.compiler.internal.buildFile
+import com.squareup.anvil.compiler.internal.createAnvilSpec
 import com.squareup.anvil.compiler.internal.joinSimpleNamesAndTruncate
 import com.squareup.anvil.compiler.internal.reference.AnnotationReference
 import com.squareup.anvil.compiler.internal.reference.AnvilCompilationExceptionClassReference
@@ -34,6 +67,11 @@ import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier.ABSTRACT
 import com.squareup.kotlinpoet.KModifier.OVERRIDE
 import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.kotlinpoet.ksp.addOriginatingKSFile
+import com.squareup.kotlinpoet.ksp.toAnnotationSpec
+import com.squareup.kotlinpoet.ksp.toClassName
+import com.squareup.kotlinpoet.ksp.toTypeName
+import com.squareup.kotlinpoet.ksp.writeTo
 import dagger.Binds
 import dagger.Module
 import dagger.Subcomponent
@@ -60,43 +98,49 @@ import java.io.File
  * interface SubcomponentInterfaceAnvilSubcomponent
  * ```
  */
-internal class ContributesSubcomponentHandlerGenerator(
-  private val classScanner: ClassScanner,
-) : PrivateCodeGenerator() {
+internal class KspContributesSubcomponentHandlerSymbolProcessor(
+  override val env: SymbolProcessorEnvironment,
+  // TODO share this
+  private val classScanner: ClassScannerKsp = ClassScannerKsp(),
+) : AnvilSymbolProcessor() {
+
+  @AutoService(SymbolProcessorProvider::class)
+  class Provider : AnvilSymbolProcessorProvider(
+    applicabilityChecker = { context -> !context.generateFactoriesOnly },
+    delegate = { env -> KspContributesSubcomponentHandlerSymbolProcessor(env) },
+  )
 
   private val triggers = mutableListOf<Trigger>()
   private val contributions = mutableSetOf<Contribution>()
-  private val replacedReferences = mutableSetOf<ClassReference>()
+  private val replacedReferences = mutableSetOf<KSClassDeclaration>()
   private val processedEvents = mutableSetOf<GenerateCodeEvent>()
 
   private var isFirstRound = true
 
-  override fun isApplicable(context: AnvilContext): Boolean = !context.generateFactoriesOnly
-
-  override fun generateCodePrivate(
-    codeGenDir: File,
-    module: ModuleDescriptor,
-    projectFiles: Collection<KtFile>,
-  ): Collection<GeneratedFileWithSources> {
+  override fun processChecked(resolver: Resolver): List<KSAnnotated> {
+    // TODO deferrals?
     if (isFirstRound) {
       isFirstRound = false
-      populateInitialContributions(module)
+      populateInitialContributions(resolver)
     }
 
     // Find new @MergeComponent (and similar triggers) that would cause generating new code.
-    triggers += projectFiles
-      .classAndInnerClassReferences(module)
-      .flatMap { it.annotations }
-      .filter { it.fqName in generationTrigger }
-      .map { Trigger(it) }
+    triggers += generationTriggers.flatMap { generationTrigger ->
+      resolver.getSymbolsWithAnnotation(generationTrigger.asString())
+        .filterIsInstance<KSClassDeclaration>()
+        .map { annotatedClass ->
+          val annotation = annotatedClass.find(generationTrigger.asString()).single()
+          Trigger(annotatedClass, annotation.scope(), annotation.exclude())
+        }
+    }
 
     // Find new contributed subcomponents in this module. If there's a trigger for them, then we
     // also need to generate code for them later.
-    contributions += projectFiles
-      .classAndInnerClassReferences(module)
-      .flatMap { it.annotations }
-      .filter { it.fqName == contributesSubcomponentFqName }
-      .map { Contribution(it) }
+    contributions += resolver.getSymbolsWithAnnotations(contributesSubcomponentFqName)
+      .map {
+        val annotation = it.find(contributesSubcomponentFqName.asString()).single()
+        Contribution(annotation)
+      }
 
     // Find all replaced subcomponents and remember them.
     replacedReferences += contributions
@@ -109,7 +153,7 @@ internal class ContributesSubcomponentHandlerGenerator(
     // Remove any contribution that was replaced by another contribution.
     contributions.removeAll { it.clazz in replacedReferences }
 
-    return contributions
+    contributions
       .flatMap { contribution ->
         triggers
           .filter { trigger ->
@@ -131,21 +175,21 @@ internal class ContributesSubcomponentHandlerGenerator(
 
         val factoryClass = findFactoryClass(contribution, generatedAnvilSubcomponent)
 
-        val content = FileSpec.buildFile(generatedPackage, componentClassName) {
+        val spec = FileSpec.createAnvilSpec(generatedPackage, componentClassName) {
           TypeSpec
             .interfaceBuilder(componentClassName)
-            .addSuperinterface(contribution.clazz.asClassName())
+            .addSuperinterface(contribution.clazz.toClassName())
             .addAnnotation(
               AnnotationSpec
                 .builder(MergeSubcomponent::class)
-                .addMember("scope = %T::class", contribution.scope.asClassName())
+                .addMember("scope = %T::class", contribution.scope.toClassName())
                 .apply {
                   fun addClassArrayMember(
                     name: String,
-                    references: List<ClassReference>,
+                    references: List<KSClassDeclaration>,
                   ) {
                     if (references.isNotEmpty()) {
-                      val classes = references.map { it.asClassName() }
+                      val classes = references.map { it.toClassName() }
                       val template = classes
                         .joinToString(prefix = "[", postfix = "]") { "%T::class" }
 
@@ -161,7 +205,8 @@ internal class ContributesSubcomponentHandlerGenerator(
             .addAnnotations(
               contribution.clazz.annotations
                 .filter { it.isDaggerScope() }
-                .map { it.toAnnotationSpec() },
+                .map { it.toAnnotationSpec() }
+                .asIterable()
             )
             .apply {
               if (factoryClass != null) {
@@ -176,24 +221,21 @@ internal class ContributesSubcomponentHandlerGenerator(
                 factoryClass,
               ),
             )
+            .addOriginatingKSFile(generateCodeEvent.trigger.clazz.containingFile!!)
             .build()
             .also { addType(it) }
         }
 
-        createGeneratedFile(
-          codeGenDir = codeGenDir,
-          packageName = generatedPackage,
-          fileName = componentClassName,
-          content = content,
-          sourceFile = generateCodeEvent.trigger.clazz.containingFileAsJavaFile,
-        )
+        spec.writeTo(env.codeGenerator, aggregating = true)
       }
+
+    return emptyList()
   }
 
   private fun generateFactory(
-    factoryReference: ClassReference,
+    factoryReference: KSClassDeclaration,
   ): TypeSpec {
-    val superclass = factoryReference.asClassName()
+    val superclass = factoryReference.toClassName()
 
     val builder = if (factoryReference.isInterface()) {
       TypeSpec
@@ -212,7 +254,7 @@ internal class ContributesSubcomponentHandlerGenerator(
   }
 
   private fun generateDaggerModule(
-    factoryReference: ClassReference,
+    factoryReference: KSClassDeclaration,
   ): TypeSpec {
     // This Dagger module will allow injecting the factory instance.
     return TypeSpec
@@ -225,7 +267,7 @@ internal class ContributesSubcomponentHandlerGenerator(
           .addAnnotation(Binds::class)
           .addModifiers(ABSTRACT)
           .addParameter("factory", ClassName.bestGuess(SUBCOMPONENT_FACTORY))
-          .returns(factoryReference.asClassName())
+          .returns(factoryReference.toClassName())
           .build(),
       )
       .build()
@@ -275,13 +317,14 @@ internal class ContributesSubcomponentHandlerGenerator(
 
   private fun findParentComponentInterface(
     contribution: Contribution,
-    factoryClass: ClassReference?,
+    factoryClass: KSClassDeclaration?,
   ): ParentComponentInterfaceHolder? {
     val contributedInnerComponentInterfaces = contribution.clazz
-      .innerClasses()
+      .declarations
+      .filterIsInstance<KSClassDeclaration>()
       .filter { it.isInterface() }
-      .filter { classReference ->
-        classReference.annotations
+      .filter { nestedClass ->
+        nestedClass.annotations
           .any {
             it.fqName == contributesToFqName && it.scope() == contribution.parentScope
           }
@@ -291,25 +334,26 @@ internal class ContributesSubcomponentHandlerGenerator(
     val componentInterface = when (contributedInnerComponentInterfaces.size) {
       0 -> return null
       1 -> contributedInnerComponentInterfaces[0]
-      else -> throw AnvilCompilationExceptionClassReference(
-        classReference = contribution.clazz,
+      else -> throw KspAnvilException(
+        node = contribution.clazz,
         message = "Expected zero or one parent component interface within " +
           "${contribution.clazz.fqName} being contributed to the parent scope.",
       )
     }
 
-    val functions = componentInterface.functions
-      .filter { it.isAbstract() && it.visibility() == PUBLIC }
+    val functions = componentInterface.getAllFunctions()
+      .filter { it.isAbstract && it.getVisibility() == Visibility.PUBLIC }
       .filter {
-        val returnType = it.returnType().asClassReference()
+        val returnType = it.returnType?.toTypeName() ?: return@filter false
         returnType == contribution.clazz || (factoryClass != null && returnType == factoryClass)
       }
+      .toList()
 
     val function = when (functions.size) {
       0 -> return null
       1 -> functions[0]
-      else -> throw AnvilCompilationExceptionClassReference(
-        classReference = contribution.clazz,
+      else -> throw KspAnvilException(
+         node = contribution.clazz,
         message = "Expected zero or one function returning the " +
           "subcomponent ${contribution.clazz.fqName}.",
       )
@@ -322,46 +366,49 @@ internal class ContributesSubcomponentHandlerGenerator(
     contribution: Contribution,
     generatedAnvilSubcomponent: ClassId,
   ): FactoryClassHolder? {
-    val contributionFqName = contribution.clazz.fqName
+    val contributionClassName = contribution.clazz.toClassName()
 
     val contributedFactories = contribution.clazz
-      .innerClasses()
-      .filter { classReference ->
-        classReference.isAnnotatedWith(contributesSubcomponentFactoryFqName)
+      .declarations
+      .filterIsInstance<KSClassDeclaration>()
+      .filter { nestedClass ->
+        nestedClass.hasAnnotation(contributesSubcomponentFactoryFqName.asString())
       }
       .onEach { factory ->
         if (!factory.isInterface() && !factory.isAbstract()) {
-          throw AnvilCompilationExceptionClassReference(
-            classReference = factory,
+          throw KspAnvilException(
+            node = factory,
             message = "A factory must be an interface or an abstract class.",
           )
         }
 
-        val createComponentFunctions = factory.functions
-          .filter { it.isAbstract() }
-          .filter { it.returnType().asClassReference().fqName == contributionFqName }
+        val createComponentFunctions = factory.getAllFunctions()
+          .filter { it.isAbstract }
+          .filter {
+            it.asMemberOf(contribution.clazz.asType(emptyList())).returnTypeOrNull()?.resolveKSClassDeclaration()?.toClassName() == contributionClassName }
+          .toList()
 
         if (createComponentFunctions.size != 1) {
-          throw AnvilCompilationExceptionClassReference(
-            classReference = factory,
+          throw KspAnvilException(
+            node = factory,
             message = "A factory must have exactly one abstract function returning the " +
-              "subcomponent $contributionFqName.",
+              "subcomponent $contributionClassName.",
           )
         }
       }
       .toList()
 
-    val classReference = when (contributedFactories.size) {
+    val originalReference = when (contributedFactories.size) {
       0 -> return null
       1 -> contributedFactories[0]
-      else -> throw AnvilCompilationExceptionClassReference(
-        classReference = contribution.clazz,
-        message = "Expected zero or one factory within $contributionFqName.",
+      else -> throw KspAnvilException(
+        node = contribution.clazz,
+        message = "Expected zero or one factory within $contributionClassName.",
       )
     }
 
     return FactoryClassHolder(
-      originalReference = classReference,
+      originalReference = originalReference,
       generatedFactoryName = generatedAnvilSubcomponent
         .createNestedClassId(Name.identifier(SUBCOMPONENT_FACTORY))
         .asClassName(),
@@ -369,13 +416,13 @@ internal class ContributesSubcomponentHandlerGenerator(
   }
 
   private fun checkReplacedSubcomponentWasNotAlreadyGenerated(
-    contributedReference: ClassReference,
-    replacedReferences: Collection<ClassReference>,
+    contributedReference: KSClassDeclaration,
+    replacedReferences: Collection<KSClassDeclaration>,
   ) {
     replacedReferences.forEach { replacedReference ->
       if (processedEvents.any { it.contribution.clazz == replacedReference }) {
-        throw AnvilCompilationExceptionClassReference(
-          classReference = contributedReference,
+        throw KspAnvilException(
+          node = contributedReference,
           message = "${contributedReference.fqName} tries to replace " +
             "${replacedReference.fqName}, but the code for ${replacedReference.fqName} was " +
             "already generated. This is not supported.",
@@ -385,13 +432,13 @@ internal class ContributesSubcomponentHandlerGenerator(
   }
 
   private fun populateInitialContributions(
-    module: ModuleDescriptor,
+    resolver: Resolver,
   ) {
     // Find all contributed subcomponents from precompiled dependencies and generate the
     // necessary code eventually if there's a trigger.
     contributions += classScanner
       .findContributedClasses(
-        module = module,
+        resolver = resolver,
         annotation = contributesSubcomponentFqName,
         scope = null,
       )
@@ -411,7 +458,7 @@ internal class ContributesSubcomponentHandlerGenerator(
   }
 
   private companion object {
-    val generationTrigger = setOf(
+    val generationTriggers = arrayOf(
       mergeComponentFqName,
       mergeSubcomponentFqName,
       // Note that we don't include @MergeModules, because we would potentially generate
@@ -422,16 +469,10 @@ internal class ContributesSubcomponentHandlerGenerator(
   }
 
   private class Trigger(
-    val clazz: ClassReference,
-    val scope: ClassReference,
-    val exclusions: List<ClassReference>,
+    val clazz: KSClassDeclaration,
+    val scope: KSType,
+    val exclusions: List<KSClassDeclaration>,
   ) {
-
-    constructor(annotation: AnnotationReference) : this(
-      clazz = annotation.declaringClass(),
-      scope = annotation.scope(),
-      exclusions = annotation.exclude(),
-    )
 
     val clazzFqName = clazz.fqName
 
@@ -458,8 +499,8 @@ internal class ContributesSubcomponentHandlerGenerator(
     }
   }
 
-  private class Contribution(val annotation: AnnotationReference) {
-    val clazz = annotation.declaringClass()
+  private class Contribution(val annotation: KSAnnotation) {
+    val clazz = annotation.declaringClass
     val scope = annotation.scope()
     val parentScope = annotation.parentScope()
 
@@ -497,15 +538,57 @@ internal class ContributesSubcomponentHandlerGenerator(
   }
 
   private class ParentComponentInterfaceHolder(
-    componentInterface: ClassReference,
-    function: MemberFunctionReference,
+    componentInterface: KSClassDeclaration,
+    function: KSFunctionDeclaration,
   ) {
-    val componentInterface = componentInterface.asClassName()
-    val functionName = function.fqName.shortName().asString()
+    val componentInterface = componentInterface.toClassName()
+    val functionName = function.simpleName.asString()
   }
 
   private class FactoryClassHolder(
-    val originalReference: ClassReference,
+    val originalReference: KSClassDeclaration,
     val generatedFactoryName: ClassName,
   )
+}
+
+/**
+ * Returns the Anvil subcomponent that will be generated for a class annotated with
+ * `ContributesSubcomponent`.
+ */
+internal fun ClassId.generatedAnvilSubcomponentClassId(parentClass: ClassId): ClassId {
+  // Encode the parent class name in the package rather than the class name itself. This avoids
+  // issues with too long class names. Dagger will generate subcomponents as inner classes and
+  // deep hierarchies will be a problem. See https://github.com/google/dagger/issues/421
+  //
+  // To avoid potential issues, encode the parent class name in the package and keep the generated
+  // class name short.
+  val parentClassPackageSuffix = if (parentClass.relativeClassName.isRoot) {
+    "root"
+  } else {
+    parentClass.relativeClassName.asString().lowercase()
+  }
+
+  // Note that use the package from the parent class and not our actual subcomponent. This is
+  // necessary to avoid conflicts as well.
+  val parentPackageName = parentClass.packageFqName
+    .safePackageString(dotPrefix = false, dotSuffix = true) + parentClassPackageSuffix
+
+  val packageFqName = if (parentPackageName.startsWith(COMPONENT_PACKAGE_PREFIX)) {
+    // This happens if the parent is generated by Anvil itself. Avoid nesting too deeply.
+    parentPackageName
+  } else {
+    "$COMPONENT_PACKAGE_PREFIX.$parentPackageName"
+  }
+
+  val segments = relativeClassName.pathSegments()
+  return ClassName(
+    packageName = packageFqName,
+    simpleNames = segments.map { it.asString() },
+  )
+    .joinSimpleNamesAndTruncate(
+      hashParams = listOf(parentClass),
+      separator = "_",
+      innerClassLength = PARENT_COMPONENT.length,
+    )
+    .asClassId(local = false)
 }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/KspContributesSubcomponentHandlerSymbolProcessor.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/KspContributesSubcomponentHandlerSymbolProcessor.kt
@@ -59,7 +59,6 @@ import com.squareup.kotlinpoet.ksp.toAnnotationSpec
 import com.squareup.kotlinpoet.ksp.toClassName
 import com.squareup.kotlinpoet.ksp.writeTo
 import org.jetbrains.kotlin.name.ClassId
-import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 
 /**

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ksp/KSAnnotationExtensions.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ksp/KSAnnotationExtensions.kt
@@ -10,6 +10,7 @@ import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSValueArgument
 import com.squareup.anvil.annotations.ContributesBinding
+import com.squareup.anvil.compiler.internal.daggerScopeFqName
 import com.squareup.anvil.compiler.internal.mapKeyFqName
 import com.squareup.anvil.compiler.qualifierFqName
 import com.squareup.kotlinpoet.ksp.toClassName
@@ -151,6 +152,7 @@ private fun KSAnnotation.isTypeAnnotatedWith(
 
 internal fun KSAnnotation.isQualifier(): Boolean = isTypeAnnotatedWith(qualifierFqName)
 internal fun KSAnnotation.isMapKey(): Boolean = isTypeAnnotatedWith(mapKeyFqName)
+internal fun KSAnnotation.isDaggerScope(): Boolean = isTypeAnnotatedWith(daggerScopeFqName)
 
 internal fun KSAnnotated.qualifierAnnotation(): KSAnnotation? =
   annotations.singleOrNull { it.isQualifier() }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ksp/KspUtil.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ksp/KspUtil.kt
@@ -9,12 +9,14 @@ import com.google.devtools.ksp.symbol.ClassKind.ANNOTATION_CLASS
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSAnnotation
 import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSFunction
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import com.google.devtools.ksp.symbol.KSModifierListOwner
 import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSTypeAlias
 import com.google.devtools.ksp.symbol.KSValueParameter
 import com.google.devtools.ksp.symbol.Modifier
+import com.squareup.anvil.compiler.fqName
 import com.squareup.anvil.compiler.internal.reference.asClassId
 import com.squareup.anvil.compiler.mergeComponentFqName
 import com.squareup.anvil.compiler.mergeInterfacesFqName
@@ -195,6 +197,11 @@ internal fun KSFunctionDeclaration.returnTypeOrNull(): KSType? =
     it.declaration.qualifiedName?.asString() != "kotlin.Unit"
   }
 
+internal fun KSFunction.returnTypeOrNull(): KSType? =
+  returnType?.takeIf {
+    it.declaration.qualifiedName?.asString() != "kotlin.Unit"
+  }
+
 internal fun Resolver.getSymbolsWithAnnotations(
   vararg annotations: FqName,
 ): Sequence<KSAnnotated> = annotations.asSequence()
@@ -265,3 +272,7 @@ internal fun KSAnnotated.mergeAnnotations(): List<KSAnnotation> {
     mergeInterfacesFqName.asString(),
   )
 }
+
+internal val KSAnnotation.fqName: FqName get() = (annotationType.resolve().declaration as KSClassDeclaration).fqName
+internal val KSType.fqName: FqName get() = resolveKSClassDeclaration()!!.fqName
+internal val KSClassDeclaration.fqName: FqName get() = toClassName().fqName

--- a/compiler/src/test/java/com/squareup/anvil/compiler/TestUtils.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/TestUtils.kt
@@ -46,7 +46,11 @@ internal fun compile(
   generateDaggerFactoriesOnly: Boolean = false,
   disableComponentMerging: Boolean = false,
   componentProcessingMode: ComponentProcessingMode = ComponentProcessingMode.NONE,
-  componentMergingBackend: ComponentMergingBackend = ComponentMergingBackend.IR,
+  componentMergingBackend: ComponentMergingBackend = if (componentProcessingMode == ComponentProcessingMode.KSP) {
+    ComponentMergingBackend.KSP
+  } else {
+    ComponentMergingBackend.IR
+  },
   trackSourceFiles: Boolean = true,
   codeGenerators: List<CodeGenerator> = emptyList(),
   allWarningsAsErrors: Boolean = true,

--- a/compiler/src/test/java/com/squareup/anvil/compiler/TestUtils.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/TestUtils.kt
@@ -24,6 +24,7 @@ import com.squareup.anvil.compiler.internal.testing.compileAnvil
 import com.squareup.anvil.compiler.internal.testing.generatedMergedComponentOrNull
 import com.squareup.anvil.compiler.internal.testing.resolveIfMerged
 import com.squareup.anvil.compiler.internal.testing.use
+import com.squareup.anvil.compiler.internal.testing.withoutMergedBindingModules
 import com.squareup.kotlinpoet.asClassName
 import com.tschuchort.compiletesting.CompilationResult
 import com.tschuchort.compiletesting.JvmCompilationResult
@@ -291,7 +292,7 @@ internal fun Class<*>.mergedModules(mergeAnnotation: KClass<out Annotation>): Ar
     is Subcomponent -> annotation.modules
     is Module -> annotation.includes
     else -> error("Unknown merge annotation class: $mergeAnnotation")
-  }
+  }.withoutMergedBindingModules()
 }
 
 internal val Class<*>.hintSubcomponent: KClass<*>?

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGeneratorTest.kt
@@ -70,6 +70,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
         @MergeComponent(Unit::class)
         interface ComponentInterface
       """.trimIndent(),
+      mode = mode,
     ) {
       val anvilComponent = subcomponentInterface.anvilComponent(componentInterface)
       assertThat(anvilComponent).isNotNull()
@@ -124,6 +125,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
         
       """.trimIndent(),
       componentProcessingMode = componentProcessingMode,
+      mode = mode,
     ) {
 
       val subA = classLoader.loadClass("com.squareup.test.$a")
@@ -171,6 +173,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
         @MergeSubcomponent(Unit::class)
         interface ComponentInterface
       """.trimIndent(),
+      mode = mode,
     ) {
       val anvilComponent = subcomponentInterface.anvilComponent(componentInterface)
       assertThat(anvilComponent).isNotNull()
@@ -197,6 +200,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
         @MergeInterfaces(Unit::class)
         interface ComponentInterface
       """.trimIndent(),
+      mode = mode,
     ) {
       val anvilComponent = subcomponentInterface.anvilComponent(componentInterface)
       assertThat(anvilComponent).isNotNull()
@@ -228,6 +232,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
         @MergeModules(Unit::class)
         interface ComponentInterface
       """.trimIndent(),
+      mode = mode,
     ) {
       assertThat(exitCode).isEqualTo(OK)
 
@@ -252,6 +257,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
         @MergeComponent(Unit::class)
         interface ComponentInterface
       """.trimIndent(),
+      mode = mode,
     ) {
       assertThat(exitCode).isEqualTo(OK)
 
@@ -278,6 +284,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
         @MergeComponent(Unit::class)
         interface ComponentInterface
       """.trimIndent(),
+      mode = mode,
     ) {
       val subcomponentInterface = classLoader
         .loadClass("com.squareup.test.Outer\$SubcomponentInterface")
@@ -309,6 +316,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
         }
         
       """.trimIndent(),
+      mode = mode,
     ) {
       val anvilComponent = subcomponentInterface.anvilComponent(
         classLoader.loadClass("com.squareup.test.Outer\$ComponentInterface"),
@@ -343,6 +351,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
         @ContributesSubcomponent(Long::class, parentScope = Int::class)
         interface SubcomponentInterface3
       """.trimIndent(),
+      mode = mode,
     ) {
       var parentComponentInterface = componentInterface
 
@@ -372,6 +381,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
         @ContributesSubcomponent(Any::class, parentScope = Unit::class)
         interface SubcomponentInterface1
       """.trimIndent(),
+      mode = mode,
     ) {
       assertThat(exitCode).isEqualTo(OK)
     }
@@ -425,6 +435,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
         @MergeComponent(Unit::class)
         interface ComponentInterface
       """.trimIndent(),
+      mode = mode,
     ) {
       val annotation = subcomponentInterface.anvilComponent(componentInterface)
         .getAnnotation(MergeSubcomponent::class.java)
@@ -452,6 +463,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
         )
         interface SubcomponentInterface
       """.trimIndent(),
+      mode = mode,
     ) {
       assertThat(exitCode).isEqualTo(OK)
     }
@@ -465,6 +477,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
         @MergeComponent(Unit::class)
         interface ComponentInterface
       """.trimIndent(),
+      mode = mode,
       previousCompilationResult = firstCompilationResult,
     ) {
       val annotation = subcomponentInterface.anvilComponent(componentInterface)
@@ -510,6 +523,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
         @MergeComponent(Unit::class)
         interface ComponentInterface
       """.trimIndent(),
+      mode = mode,
     ) {
       val annotation = subcomponentInterface.anvilComponent(componentInterface)
         .getAnnotation(MergeSubcomponent::class.java)
@@ -555,6 +569,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
         )
         interface SubcomponentInterface
       """.trimIndent(),
+      mode = mode,
     ) {
       assertThat(exitCode).isEqualTo(OK)
     }
@@ -597,6 +612,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
         @MergeComponent(Unit::class)
         interface ComponentInterface
       """.trimIndent(),
+      mode = mode,
     ) {
       val parentComponent =
         subcomponentInterface.anvilComponent(componentInterface).parentComponentInterface
@@ -632,6 +648,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
         @MergeComponent(Unit::class)
         interface ComponentInterface
       """.trimIndent(),
+      mode = mode,
     ) {
       val parentComponent =
         subcomponentInterface.anvilComponent(componentInterface).parentComponentInterface
@@ -670,6 +687,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
           }
         }
       """,
+      mode = mode,
     ) {
       assertThat(exitCode).isEqualTo(OK)
     }
@@ -683,6 +701,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
         @MergeComponent(Unit::class)
         interface ComponentInterface
       """,
+      mode = mode,
       previousCompilationResult = firstCompilationResult,
     ) {
       val parentComponent =
@@ -725,6 +744,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
         @MergeComponent(Unit::class)
         interface ComponentInterface
       """.trimIndent(),
+      mode = mode,
     ) {
       val parentComponent =
         subcomponentInterface.anvilComponent(componentInterface).parentComponentInterface
@@ -768,6 +788,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
         @MergeComponent(Unit::class)
         interface ComponentInterface
       """,
+      mode = mode,
       componentProcessingMode = componentProcessingMode,
     ) {
       val daggerComponent = componentInterface.daggerComponent.declaredMethods
@@ -825,6 +846,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
         @MergeComponent(Int::class)
         interface ComponentInterface2
       """,
+      mode = mode,
       // Keep Dagger enabled, because it complained initially.
       componentProcessingMode = componentProcessingMode,
     ) {
@@ -871,6 +893,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
       )
       interface ComponentInterface
       """,
+      mode = mode,
     ) {
       assertThat(exitCode).isEqualTo(OK)
 
@@ -900,6 +923,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
       )
       interface ComponentInterface
       """,
+      mode = mode,
     ) {
       assertThat(exitCode).isEqualTo(OK)
 
@@ -929,6 +953,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
       )
       interface ComponentInterface
       """,
+      mode = mode,
     ) {
       assertThat(exitCode).isEqualTo(OK)
 
@@ -962,6 +987,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
       )
       interface ContributingInterface
       """,
+      mode = mode,
     ) {
       // Fails because the component is never generated.
       assertFailsWith<ClassNotFoundException> {
@@ -995,6 +1021,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
       )
       interface ComponentInterface
       """,
+      mode = mode,
       expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
       assertThat(messages).contains(
@@ -1033,6 +1060,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
         @MergeComponent(Unit::class)
         interface ComponentInterface
       """.trimIndent(),
+      mode = mode,
     ) {
       val createFactoryFunction = subcomponentInterface.anvilComponent(componentInterface)
         .parentComponentInterface
@@ -1078,6 +1106,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
         @MergeComponent(Unit::class)
         interface ComponentInterface
       """.trimIndent(),
+      mode = mode,
     ) {
       val createFactoryFunction = subcomponentInterface.anvilComponent(componentInterface)
         .parentComponentInterface
@@ -1117,6 +1146,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
         @MergeComponent(Unit::class)
         interface ComponentInterface
       """.trimIndent(),
+      mode = mode,
     ) {
       val parentComponent =
         subcomponentInterface.anvilComponent(componentInterface).parentComponentInterface
@@ -1168,6 +1198,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
         @MergeComponent(Unit::class)
         interface ComponentInterface
       """,
+      mode = mode,
       componentProcessingMode = componentProcessingMode,
     ) {
       val daggerComponent = componentInterface.daggerComponent.declaredMethods
@@ -1229,6 +1260,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
 
         class TestClass @Inject constructor(val factory: SubcomponentInterface.ComponentFactory)
       """,
+      mode = mode,
       componentProcessingMode = componentProcessingMode,
     ) {
       val daggerComponent = componentInterface.daggerComponent.declaredMethods
@@ -1292,6 +1324,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
 
         class TestClass @Inject constructor(val factory: SubcomponentInterface.ComponentFactory)
       """,
+      mode = mode,
       componentProcessingMode = componentProcessingMode,
     ) {
       val daggerComponent = componentInterface2.daggerComponent.declaredMethods
@@ -1358,6 +1391,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
         @MergeComponent(Unit::class)
         interface ComponentInterface1
       """.trimIndent(),
+      mode = mode,
       componentProcessingMode = componentProcessingMode,
     ) {
       assertThat(exitCode).isEqualTo(OK)
@@ -1376,6 +1410,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
         @MergeComponent(Unit::class)
         interface ComponentInterface2
       """.trimIndent(),
+      mode = mode,
       previousCompilationResult = firstCompilationResult,
       componentProcessingMode = componentProcessingMode,
     ) {
@@ -1430,6 +1465,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
         @MergeComponent(Unit::class)
         interface ComponentInterface2
       """,
+      mode = mode,
     ) {
       val modules1 = componentInterface1.getAnnotation(Component::class.java).modules.toList()
       val modules2 = componentInterface2.getAnnotation(Component::class.java).modules.toList()
@@ -1493,6 +1529,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
 
         class TestClass @Inject constructor(val factory: SubcomponentInterface.ComponentFactory)
       """,
+      mode = mode,
       componentProcessingMode = componentProcessingMode,
     ) {
       val daggerComponent1 = componentInterface1.daggerComponent.declaredMethods
@@ -1548,6 +1585,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
         @MergeComponent(Unit::class)
         interface ComponentInterface
       """.trimIndent(),
+      mode = mode,
     ) {
       val anvilComponent = subcomponentInterface.anvilComponent(componentInterface)
       assertThat(anvilComponent).isNotNull()
@@ -1581,6 +1619,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
         @MergeComponent(Unit::class)
         interface ComponentInterface
       """.trimIndent(),
+      mode = mode,
     ) {
       val anvilComponent = subcomponentInterface.anvilComponent(componentInterface)
       assertThat(anvilComponent).isNotNull()
@@ -1631,6 +1670,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
         @MergeComponent(Unit::class)
         interface ComponentInterface1
       """,
+      mode = mode,
       componentProcessingMode = componentProcessingMode,
     ) {
       val daggerComponent = componentInterface1.daggerComponent.declaredMethods
@@ -1677,6 +1717,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
         @MergeComponent(Unit::class)
         interface ComponentInterface2
       """,
+      mode = mode,
       componentProcessingMode = componentProcessingMode,
       previousCompilationResult = firstResult,
     ) {
@@ -1724,6 +1765,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
       @MergeComponent(Any::class)
       interface ComponentInterface2
       """,
+      mode = mode,
     ) {
       val parentComponentInterface1 = subcomponentInterface
         .anvilComponent(componentInterface1)
@@ -1768,6 +1810,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
         @ContributesSubcomponent(scope = Any::class, parentScope = Unit::class)
         interface SubcomponentInterfacewithVeryVeryVeryVeryVeryVeryVeryLongName
       """,
+      mode = mode,
       componentProcessingMode = componentProcessingMode,
     ) {
       assertThat(exitCode).isEqualTo(OK)
@@ -1776,6 +1819,8 @@ class ContributesSubcomponentHandlerGeneratorTest(
 
   @Test fun `an @ContributeSubcomponent class can be generated`() {
     assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
+    // TODO support KSP in this too
+    assumeTrue(mode is AnvilCompilationMode.Embedded)
     val codeGenerator = simpleCodeGenerator { clazz ->
       clazz
         .takeIf { it.isAnnotatedWith(mergeComponentFqName) }
@@ -1812,7 +1857,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
         @MergeComponent(Unit::class)
         interface ComponentInterface
       """,
-      codeGenerators = listOf(codeGenerator),
+      mode = AnvilCompilationMode.Embedded(listOf(codeGenerator)),
     ) {
       val parentComponentInterface1 = subcomponentInterface1
         .anvilComponent(componentInterface)
@@ -1828,6 +1873,8 @@ class ContributesSubcomponentHandlerGeneratorTest(
 
   @Test fun `an @ContributeSubcomponent class can be generated with a custom factory`() {
     assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
+    // TODO support KSP in this too
+    assumeTrue(mode is AnvilCompilationMode.Embedded)
     val codeGenerator = simpleCodeGenerator { clazz ->
       clazz
         .takeIf { it.isAnnotatedWith(mergeComponentFqName) }
@@ -1875,7 +1922,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
         @MergeComponent(Unit::class)
         interface ComponentInterface
       """,
-      codeGenerators = listOf(codeGenerator),
+      mode = AnvilCompilationMode.Embedded(listOf(codeGenerator)),
     ) {
       val parentComponentInterface1 = subcomponentInterface1
         .anvilComponent(componentInterface)
@@ -1914,6 +1961,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
         @MergeComponent(Unit::class)
         interface ComponentInterface
       """,
+      mode = mode,
     ) {
       val parentComponentInterface2 = subcomponentInterface2
         .anvilComponent(componentInterface)
@@ -1971,6 +2019,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
         @MergeComponent(Unit::class)
         interface ComponentInterface
       """,
+      mode = mode,
     ) {
       val annotation = subcomponentInterface2.anvilComponent(componentInterface)
         .getAnnotation(MergeSubcomponent::class.java)
@@ -2011,6 +2060,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
         @MergeComponent(Unit::class)
         interface ComponentInterface
       """,
+      mode = mode,
     ) {
       val parentComponentInterface2 = subcomponentInterface2
         .anvilComponent(componentInterface)
@@ -2040,6 +2090,8 @@ class ContributesSubcomponentHandlerGeneratorTest(
   @Test
   fun `a previously generated contributed subcomponent can be replaced in a later round of generations`() {
     assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
+    // TODO support KSP in this too
+    assumeTrue(mode is AnvilCompilationMode.Embedded)
     val codeGenerator = simpleCodeGenerator { clazz ->
       clazz
         .takeIf { it.isAnnotatedWith(mergeComponentFqName) }
@@ -2076,7 +2128,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
         @MergeComponent(Unit::class)
         interface ComponentInterface
       """,
-      codeGenerators = listOf(codeGenerator),
+      mode = AnvilCompilationMode.Embedded(listOf(codeGenerator)),
     ) {
       val parentComponentInterface2 = subcomponentInterface2
         .anvilComponent(componentInterface)

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGeneratorTest.kt
@@ -87,7 +87,9 @@ class ContributesSubcomponentHandlerGeneratorTest(
   @Test fun `generation works for a nested contributed subcomponent with a very long name`() {
     assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
     // This test tests legacy behavior that we no longer need to do in KSP processing
-    assumeFalse(mode is AnvilCompilationMode.Ksp && componentProcessingMode != ComponentProcessingMode.KSP)
+    assumeFalse(
+      mode is AnvilCompilationMode.Ksp && componentProcessingMode != ComponentProcessingMode.KSP,
+    )
 
     // These name lengths are arbitrary. They're long enough to be somewhat realistic,
     // but short enough that most file names won't become obnoxiously long for no reason.
@@ -605,7 +607,9 @@ class ContributesSubcomponentHandlerGeneratorTest(
   fun `there is a parent component interface automatically generated without declaring one explicitly`() {
     assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
     // This test tests legacy behavior that we no longer need to do in KSP processing
-    assumeFalse(mode is AnvilCompilationMode.Ksp && componentProcessingMode != ComponentProcessingMode.KSP)
+    assumeFalse(
+      mode is AnvilCompilationMode.Ksp && componentProcessingMode != ComponentProcessingMode.KSP,
+    )
     compile(
       """
         package com.squareup.test
@@ -636,7 +640,9 @@ class ContributesSubcomponentHandlerGeneratorTest(
   fun `the parent component interface extends a manually declared component interface with the same scope`() {
     assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
     // This test tests legacy behavior that we no longer need to do in KSP processing
-    assumeFalse(mode is AnvilCompilationMode.Ksp && componentProcessingMode != ComponentProcessingMode.KSP)
+    assumeFalse(
+      mode is AnvilCompilationMode.Ksp && componentProcessingMode != ComponentProcessingMode.KSP,
+    )
     compile(
       """
         package com.squareup.test
@@ -681,7 +687,9 @@ class ContributesSubcomponentHandlerGeneratorTest(
   fun `the parent component interface extends a manually declared component interface with the same scope with multiple compilations`() {
     assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
     // This test tests legacy behavior that we no longer need to do in KSP processing
-    assumeFalse(mode is AnvilCompilationMode.Ksp && componentProcessingMode != ComponentProcessingMode.KSP)
+    assumeFalse(
+      mode is AnvilCompilationMode.Ksp && componentProcessingMode != ComponentProcessingMode.KSP,
+    )
     val firstCompilationResult = compile(
       """
         package com.squareup.test
@@ -826,7 +834,9 @@ class ContributesSubcomponentHandlerGeneratorTest(
   @Test
   fun `the parent interface of a contributed subcomponent is picked up by components and other contributed subcomponents`() {
     // This test tests legacy behavior that we no longer need to do in KSP processing
-    assumeFalse(mode is AnvilCompilationMode.Ksp && componentProcessingMode != ComponentProcessingMode.KSP)
+    assumeFalse(
+      mode is AnvilCompilationMode.Ksp && componentProcessingMode != ComponentProcessingMode.KSP,
+    )
     compile(
       """
         package com.squareup.test
@@ -1048,7 +1058,9 @@ class ContributesSubcomponentHandlerGeneratorTest(
   fun `the parent component interface can return a factory`() {
     assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
     // This test tests legacy behavior that we no longer need to do in KSP processing
-    assumeFalse(mode is AnvilCompilationMode.Ksp && componentProcessingMode != ComponentProcessingMode.KSP)
+    assumeFalse(
+      mode is AnvilCompilationMode.Ksp && componentProcessingMode != ComponentProcessingMode.KSP,
+    )
     compile(
       """
         package com.squareup.test
@@ -1096,7 +1108,9 @@ class ContributesSubcomponentHandlerGeneratorTest(
   fun `a factory can be an abstract class`() {
     assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
     // This test tests legacy behavior that we no longer need to do in KSP processing
-    assumeFalse(mode is AnvilCompilationMode.Ksp && componentProcessingMode != ComponentProcessingMode.KSP)
+    assumeFalse(
+      mode is AnvilCompilationMode.Ksp && componentProcessingMode != ComponentProcessingMode.KSP,
+    )
     compile(
       """
         package com.squareup.test
@@ -1143,7 +1157,9 @@ class ContributesSubcomponentHandlerGeneratorTest(
   @Test fun `the generated parent component interface returns the factory if one is present`() {
     assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
     // This test tests legacy behavior that we no longer need to do in KSP processing
-    assumeFalse(mode is AnvilCompilationMode.Ksp && componentProcessingMode != ComponentProcessingMode.KSP)
+    assumeFalse(
+      mode is AnvilCompilationMode.Ksp && componentProcessingMode != ComponentProcessingMode.KSP,
+    )
     compile(
       """
         package com.squareup.test
@@ -1460,7 +1476,9 @@ class ContributesSubcomponentHandlerGeneratorTest(
   fun `the correct generated factory is bound`() {
     assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
     // This test tests legacy behavior that we no longer need to do in KSP processing
-    assumeFalse(mode is AnvilCompilationMode.Ksp && componentProcessingMode != ComponentProcessingMode.KSP)
+    assumeFalse(
+      mode is AnvilCompilationMode.Ksp && componentProcessingMode != ComponentProcessingMode.KSP,
+    )
     compile(
       """
         package com.squareup.test

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGeneratorTest.kt
@@ -11,6 +11,7 @@ import com.squareup.anvil.compiler.compile
 import com.squareup.anvil.compiler.componentInterface
 import com.squareup.anvil.compiler.contributingInterface
 import com.squareup.anvil.compiler.daggerModule1
+import com.squareup.anvil.compiler.includeKspTests
 import com.squareup.anvil.compiler.internal.testing.AnvilCompilationMode
 import com.squareup.anvil.compiler.internal.testing.ComponentProcessingMode
 import com.squareup.anvil.compiler.internal.testing.extends
@@ -49,12 +50,14 @@ class ContributesSubcomponentHandlerGeneratorTest(
     @JvmStatic
     @Parameters(name = "{0} {1}")
     fun parameters(): Collection<Any> {
-      return listOf(
-        arrayOf(ComponentProcessingMode.NONE, AnvilCompilationMode.Embedded()),
-        arrayOf(ComponentProcessingMode.NONE, AnvilCompilationMode.Ksp()),
-        arrayOf(ComponentProcessingMode.KAPT, AnvilCompilationMode.Embedded()),
-        arrayOf(ComponentProcessingMode.KSP, AnvilCompilationMode.Ksp()),
-      )
+      return buildList {
+        add(arrayOf(ComponentProcessingMode.NONE, AnvilCompilationMode.Embedded()))
+        add(arrayOf(ComponentProcessingMode.KAPT, AnvilCompilationMode.Embedded()))
+        if (includeKspTests()) {
+          add(arrayOf(ComponentProcessingMode.NONE, AnvilCompilationMode.Ksp()))
+          add(arrayOf(ComponentProcessingMode.KSP, AnvilCompilationMode.Ksp()))
+        }
+      }
     }
   }
 

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGeneratorTest.kt
@@ -47,9 +47,9 @@ class ContributesSubcomponentHandlerGeneratorTest(
     fun parameters(): Collection<Any> {
       return listOf(
         arrayOf(ComponentProcessingMode.NONE, AnvilCompilationMode.Embedded()),
-        // arrayOf(ComponentProcessingMode.NONE, AnvilCompilationMode.Ksp()),
+        arrayOf(ComponentProcessingMode.NONE, AnvilCompilationMode.Ksp()),
         arrayOf(ComponentProcessingMode.KAPT, AnvilCompilationMode.Embedded()),
-        // arrayOf(ComponentProcessingMode.KSP, AnvilCompilationMode.Ksp()),
+        arrayOf(ComponentProcessingMode.KSP, AnvilCompilationMode.Ksp()),
       )
     }
   }

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGeneratorTest.kt
@@ -14,6 +14,7 @@ import com.squareup.anvil.compiler.daggerModule1
 import com.squareup.anvil.compiler.internal.testing.AnvilCompilationMode
 import com.squareup.anvil.compiler.internal.testing.ComponentProcessingMode
 import com.squareup.anvil.compiler.internal.testing.extends
+import com.squareup.anvil.compiler.internal.testing.resolveIfMerged
 import com.squareup.anvil.compiler.internal.testing.shouldNotExtend
 import com.squareup.anvil.compiler.internal.testing.simpleCodeGenerator
 import com.squareup.anvil.compiler.internal.testing.use
@@ -1267,7 +1268,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
         .single { it.name == "create" }
         .invoke(null)
 
-      val testClassInstance = componentInterface.declaredMethods
+      val testClassInstance = componentInterface.methods
         .single { it.name == "testClass" }
         .invoke(daggerComponent)
 

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGeneratorTest.kt
@@ -11,6 +11,7 @@ import com.squareup.anvil.compiler.compile
 import com.squareup.anvil.compiler.componentInterface
 import com.squareup.anvil.compiler.contributingInterface
 import com.squareup.anvil.compiler.daggerModule1
+import com.squareup.anvil.compiler.internal.testing.AnvilCompilationMode
 import com.squareup.anvil.compiler.internal.testing.ComponentProcessingMode
 import com.squareup.anvil.compiler.internal.testing.extends
 import com.squareup.anvil.compiler.internal.testing.shouldNotExtend
@@ -26,13 +27,36 @@ import dagger.Component
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldEndWith
 import org.jetbrains.kotlin.descriptors.runtime.structure.classId
-import org.junit.jupiter.api.Test
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.runners.Parameterized.Parameters
 import javax.inject.Singleton
 import kotlin.test.assertFailsWith
 
-class ContributesSubcomponentHandlerGeneratorTest {
+@RunWith(Parameterized::class)
+class ContributesSubcomponentHandlerGeneratorTest(
+  private val componentProcessingMode: ComponentProcessingMode,
+  private val mode: AnvilCompilationMode,
+) {
+
+  companion object {
+    @JvmStatic
+    @Parameters(name = "{0} {1}")
+    fun parameters(): Collection<Any> {
+      return listOf(
+        arrayOf(ComponentProcessingMode.NONE, AnvilCompilationMode.Embedded()),
+        // arrayOf(ComponentProcessingMode.NONE, AnvilCompilationMode.Ksp()),
+        arrayOf(ComponentProcessingMode.KAPT, AnvilCompilationMode.Embedded()),
+        // arrayOf(ComponentProcessingMode.KSP, AnvilCompilationMode.Ksp()),
+      )
+    }
+  }
+
 
   @Test fun `there is a subcomponent generated for a @MergeComponent`() {
+    assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
     compile(
       """
         package com.squareup.test
@@ -57,6 +81,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
   }
 
   @Test fun `generation works for a nested contributed subcomponent with a very long name`() {
+    assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
 
     // These name lengths are arbitrary. They're long enough to be somewhat realistic,
     // but short enough that most file names won't become obnoxiously long for no reason.
@@ -98,7 +123,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
         }
         
       """.trimIndent(),
-      componentProcessingMode = ComponentProcessingMode.KAPT,
+      componentProcessingMode = componentProcessingMode,
     ) {
 
       val subA = classLoader.loadClass("com.squareup.test.$a")
@@ -132,6 +157,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
   }
 
   @Test fun `there is a subcomponent generated for a @MergeSubcomponent`() {
+    assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
     compile(
       """
         package com.squareup.test
@@ -157,6 +183,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
 
   @Test
   fun `there is a subcomponent generated for a @MergeInterfaces and the parent component is added to the interface`() {
+    assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
     compile(
       """
         package com.squareup.test
@@ -187,6 +214,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
   }
 
   @Test fun `there is no subcomponent generated for a @MergeModules`() {
+    assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
     compile(
       """
         package com.squareup.test
@@ -210,6 +238,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
   }
 
   @Test fun `there is no subcomponent generated for a mismatching scopes`() {
+    assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
     compile(
       """
         package com.squareup.test
@@ -233,6 +262,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
   }
 
   @Test fun `there is a subcomponent generated for an inner class`() {
+    assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
     compile(
       """
         package com.squareup.test
@@ -262,6 +292,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
   }
 
   @Test fun `there is a subcomponent generated for an inner parent class`() {
+    assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
     compile(
       """
         package com.squareup.test
@@ -291,6 +322,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
   }
 
   @Test fun `there is a subcomponent generated in a chain of contributed subcomponents`() {
+    assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
     // This test will exercise multiple rounds of code generation.
     compile(
       """
@@ -330,6 +362,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
   }
 
   @Test fun `there is a subcomponent generated with separate compilations`() {
+    assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
     val firstCompilationResult = compile(
       """
         package com.squareup.test
@@ -370,6 +403,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
   }
 
   @Test fun `Dagger modules can be added manually`() {
+    assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
     compile(
       """
         package com.squareup.test
@@ -400,6 +434,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
   }
 
   @Test fun `Dagger modules can be added manually with multiple compilations`() {
+    assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
     val firstCompilationResult = compile(
       """
         package com.squareup.test
@@ -440,6 +475,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
   }
 
   @Test fun `Dagger modules, component interfaces and bindings can be excluded`() {
+    assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
     compile(
       """
         package com.squareup.test
@@ -488,6 +524,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
 
   @Test
   fun `Dagger modules, component interfaces and bindings can be excluded with multiple compilations`() {
+    assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
     val firstCompilationResult = compile(
       """
         package com.squareup.test
@@ -546,6 +583,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
 
   @Test
   fun `there is a parent component interface automatically generated without declaring one explicitly`() {
+    assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
     compile(
       """
         package com.squareup.test
@@ -573,6 +611,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
 
   @Test
   fun `the parent component interface extends a manually declared component interface with the same scope`() {
+    assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
     compile(
       """
         package com.squareup.test
@@ -614,6 +653,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
 
   @Test
   fun `the parent component interface extends a manually declared component interface with the same scope with multiple compilations`() {
+    assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
     val firstCompilationResult = compile(
       """
         package com.squareup.test
@@ -665,6 +705,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
 
   @Test
   fun `the parent component interface does not extend a manually declared component interface with a different scope`() {
+    assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
     compile(
       """
         package com.squareup.test
@@ -695,6 +736,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
 
   @Test
   fun `Dagger generates the real component and subcomponent and they can be instantiated through the component interfaces`() {
+    assumeTrue(componentProcessingMode != ComponentProcessingMode.NONE)
     checkFullTestRun()
 
     compile(
@@ -726,7 +768,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
         @MergeComponent(Unit::class)
         interface ComponentInterface
       """,
-      componentProcessingMode = ComponentProcessingMode.KAPT,
+      componentProcessingMode = componentProcessingMode,
     ) {
       val daggerComponent = componentInterface.daggerComponent.declaredMethods
         .single { it.name == "create" }
@@ -784,7 +826,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
         interface ComponentInterface2
       """,
       // Keep Dagger enabled, because it complained initially.
-      componentProcessingMode = ComponentProcessingMode.KAPT,
+      componentProcessingMode = componentProcessingMode,
     ) {
 
       val anvilComponent1 = subcomponentInterface1.anvilComponent(componentInterface1)
@@ -812,6 +854,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
   }
 
   @Test fun `contributed subcomponents can be excluded with @MergeComponent`() {
+    assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
     compile(
       """
       package com.squareup.test
@@ -840,6 +883,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
   }
 
   @Test fun `contributed subcomponents can be excluded with @MergeSubcomponent`() {
+    assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
     compile(
       """
       package com.squareup.test
@@ -868,6 +912,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
   }
 
   @Test fun `contributed subcomponents can be excluded with @MergeModules`() {
+    assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
     compile(
       """
       package com.squareup.test
@@ -895,6 +940,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
   }
 
   @Test fun `contributed subcomponents can be excluded in one component but not the other`() {
+    assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
     compile(
       """
       package com.squareup.test
@@ -932,6 +978,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
   }
 
   @Test fun `contributed subcomponents can be excluded only with a matching scope`() {
+    assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
     compile(
       """
       package com.squareup.test
@@ -960,6 +1007,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
 
   @Test
   fun `the parent component interface can return a factory`() {
+    assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
     compile(
       """
         package com.squareup.test
@@ -1004,6 +1052,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
 
   @Test
   fun `a factory can be an abstract class`() {
+    assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
     compile(
       """
         package com.squareup.test
@@ -1047,6 +1096,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
   }
 
   @Test fun `the generated parent component interface returns the factory if one is present`() {
+    assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
     compile(
       """
         package com.squareup.test
@@ -1085,6 +1135,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
   }
 
   @Test fun `Dagger generates the real component and subcomponent with a factory`() {
+    assumeTrue(componentProcessingMode != ComponentProcessingMode.NONE)
     checkFullTestRun()
 
     compile(
@@ -1117,7 +1168,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
         @MergeComponent(Unit::class)
         interface ComponentInterface
       """,
-      componentProcessingMode = ComponentProcessingMode.KAPT,
+      componentProcessingMode = componentProcessingMode,
     ) {
       val daggerComponent = componentInterface.daggerComponent.declaredMethods
         .single { it.name == "create" }
@@ -1146,6 +1197,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
 
   @Test
   fun `the generated factory can be injected`() {
+    assumeTrue(componentProcessingMode != ComponentProcessingMode.NONE)
     checkFullTestRun()
 
     compile(
@@ -1177,7 +1229,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
 
         class TestClass @Inject constructor(val factory: SubcomponentInterface.ComponentFactory)
       """,
-      componentProcessingMode = ComponentProcessingMode.KAPT,
+      componentProcessingMode = componentProcessingMode,
     ) {
       val daggerComponent = componentInterface.daggerComponent.declaredMethods
         .single { it.name == "create" }
@@ -1205,6 +1257,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
 
   @Test
   fun `the generated factory can be injected in a nested subcomponent`() {
+    assumeTrue(componentProcessingMode != ComponentProcessingMode.NONE)
     checkFullTestRun()
 
     compile(
@@ -1239,7 +1292,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
 
         class TestClass @Inject constructor(val factory: SubcomponentInterface.ComponentFactory)
       """,
-      componentProcessingMode = ComponentProcessingMode.KAPT,
+      componentProcessingMode = componentProcessingMode,
     ) {
       val daggerComponent = componentInterface2.daggerComponent.declaredMethods
         .single { it.name == "create" }
@@ -1271,6 +1324,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
 
   @Test
   fun `the generated factory can be injected with multiple compilations`() {
+    assumeTrue(componentProcessingMode != ComponentProcessingMode.NONE)
     checkFullTestRun()
 
     val firstCompilationResult = compile(
@@ -1304,7 +1358,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
         @MergeComponent(Unit::class)
         interface ComponentInterface1
       """.trimIndent(),
-      componentProcessingMode = ComponentProcessingMode.KAPT,
+      componentProcessingMode = componentProcessingMode,
     ) {
       assertThat(exitCode).isEqualTo(OK)
 
@@ -1323,7 +1377,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
         interface ComponentInterface2
       """.trimIndent(),
       previousCompilationResult = firstCompilationResult,
-      componentProcessingMode = ComponentProcessingMode.KAPT,
+      componentProcessingMode = componentProcessingMode,
     ) {
       assertThat(exitCode).isEqualTo(OK)
 
@@ -1349,6 +1403,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
 
   @Test
   fun `the correct generated factory is bound`() {
+    assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
     compile(
       """
         package com.squareup.test
@@ -1401,6 +1456,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
 
   @Test
   fun `the correct generated factory is bound - with Dagger`() {
+    assumeTrue(componentProcessingMode != ComponentProcessingMode.NONE)
     checkFullTestRun()
 
     compile(
@@ -1437,7 +1493,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
 
         class TestClass @Inject constructor(val factory: SubcomponentInterface.ComponentFactory)
       """,
-      componentProcessingMode = ComponentProcessingMode.KAPT,
+      componentProcessingMode = componentProcessingMode,
     ) {
       val daggerComponent1 = componentInterface1.daggerComponent.declaredMethods
         .single { it.name == "create" }
@@ -1476,6 +1532,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
   }
 
   @Test fun `the generated subcomponent contains the same scope annotation`() {
+    assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
     compile(
       """
         package com.squareup.test
@@ -1501,6 +1558,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
   }
 
   @Test fun `the generated subcomponent contains the same scope annotation - custom scope`() {
+    assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
     compile(
       """
         package com.squareup.test
@@ -1540,6 +1598,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
   }
 
   @Test fun `subcomponent can be contributed and bindings replaced in a 2nd compilation`() {
+    assumeTrue(componentProcessingMode != ComponentProcessingMode.NONE)
     checkFullTestRun()
 
     // This test simulates a compilation in the main source set and test/androidTest source set,
@@ -1572,7 +1631,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
         @MergeComponent(Unit::class)
         interface ComponentInterface1
       """,
-      componentProcessingMode = ComponentProcessingMode.KAPT,
+      componentProcessingMode = componentProcessingMode,
     ) {
       val daggerComponent = componentInterface1.daggerComponent.declaredMethods
         .single { it.name == "create" }
@@ -1618,7 +1677,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
         @MergeComponent(Unit::class)
         interface ComponentInterface2
       """,
-      componentProcessingMode = ComponentProcessingMode.KAPT,
+      componentProcessingMode = componentProcessingMode,
       previousCompilationResult = firstResult,
     ) {
       val daggerComponent = componentInterface2.daggerComponent.declaredMethods
@@ -1648,6 +1707,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
   }
 
   @Test fun `contributed subcomponent parent interfaces are merged with the right component`() {
+    assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
     compile(
       """
       package com.squareup.test
@@ -1708,13 +1768,14 @@ class ContributesSubcomponentHandlerGeneratorTest {
         @ContributesSubcomponent(scope = Any::class, parentScope = Unit::class)
         interface SubcomponentInterfacewithVeryVeryVeryVeryVeryVeryVeryLongName
       """,
-      componentProcessingMode = ComponentProcessingMode.KAPT,
+      componentProcessingMode = componentProcessingMode,
     ) {
       assertThat(exitCode).isEqualTo(OK)
     }
   }
 
   @Test fun `an @ContributeSubcomponent class can be generated`() {
+    assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
     val codeGenerator = simpleCodeGenerator { clazz ->
       clazz
         .takeIf { it.isAnnotatedWith(mergeComponentFqName) }
@@ -1766,6 +1827,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
   }
 
   @Test fun `an @ContributeSubcomponent class can be generated with a custom factory`() {
+    assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
     val codeGenerator = simpleCodeGenerator { clazz ->
       clazz
         .takeIf { it.isAnnotatedWith(mergeComponentFqName) }
@@ -1828,6 +1890,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
   }
 
   @Test fun `a contributed subcomponent can be replaced`() {
+    assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
     compile(
       """
         package com.squareup.test
@@ -1866,6 +1929,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
 
   @Test
   fun `a replaced subcomponent's exclusions for Dagger modules, component interfaces and bindings are ignored`() {
+    assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
     compile(
       """
         package com.squareup.test
@@ -1917,6 +1981,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
 
   @Test
   fun `a subcomponent can replace another subcomponent with a different parent scope`() {
+    assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
     compile(
       """
         package com.squareup.test
@@ -1974,6 +2039,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
 
   @Test
   fun `a previously generated contributed subcomponent can be replaced in a later round of generations`() {
+    assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
     val codeGenerator = simpleCodeGenerator { clazz ->
       clazz
         .takeIf { it.isAnnotatedWith(mergeComponentFqName) }

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGeneratorTest.kt
@@ -30,30 +30,31 @@ import io.kotest.matchers.string.shouldEndWith
 import org.jetbrains.kotlin.descriptors.runtime.structure.classId
 import org.junit.Assume.assumeTrue
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.Parameterized
-import org.junit.runners.Parameterized.Parameters
 import javax.inject.Singleton
+import kotlin.io.path.createTempDirectory
 import kotlin.test.assertFailsWith
 
-@RunWith(Parameterized::class)
+// @RunWith(Parameterized::class)
 class ContributesSubcomponentHandlerGeneratorTest(
-  private val componentProcessingMode: ComponentProcessingMode,
-  private val mode: AnvilCompilationMode,
+  // private val componentProcessingMode: ComponentProcessingMode,
+  // private val mode: AnvilCompilationMode,
 ) {
 
-  companion object {
-    @JvmStatic
-    @Parameters(name = "{0} {1}")
-    fun parameters(): Collection<Any> {
-      return listOf(
-        arrayOf(ComponentProcessingMode.NONE, AnvilCompilationMode.Embedded()),
-        arrayOf(ComponentProcessingMode.NONE, AnvilCompilationMode.Ksp()),
-        arrayOf(ComponentProcessingMode.KAPT, AnvilCompilationMode.Embedded()),
-        arrayOf(ComponentProcessingMode.KSP, AnvilCompilationMode.Ksp()),
-      )
-    }
-  }
+  private val componentProcessingMode: ComponentProcessingMode = ComponentProcessingMode.KSP
+  private val mode: AnvilCompilationMode = AnvilCompilationMode.Ksp()
+
+  // companion object {
+  //   @JvmStatic
+  //   @Parameters(name = "{0} {1}")
+  //   fun parameters(): Collection<Any> {
+  //     return listOf(
+  //       // arrayOf(ComponentProcessingMode.NONE, AnvilCompilationMode.Embedded()),
+  //       arrayOf(ComponentProcessingMode.NONE, AnvilCompilationMode.Ksp()),
+  //       // arrayOf(ComponentProcessingMode.KAPT, AnvilCompilationMode.Embedded()),
+  //       // arrayOf(ComponentProcessingMode.KSP, AnvilCompilationMode.Ksp()),
+  //     )
+  //   }
+  // }
 
 
   @Test fun `there is a subcomponent generated for a @MergeComponent`() {
@@ -815,6 +816,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
 
   @Test
   fun `the parent interface of a contributed subcomponent is picked up by components and other contributed subcomponents`() {
+    val dir = createTempDirectory()
     compile(
       """
         package com.squareup.test
@@ -850,6 +852,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
       mode = mode,
       // Keep Dagger enabled, because it complained initially.
       componentProcessingMode = componentProcessingMode,
+      workingDir = dir.toFile()
     ) {
 
       val anvilComponent1 = subcomponentInterface1.anvilComponent(componentInterface1)

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGeneratorTest.kt
@@ -14,6 +14,7 @@ import com.squareup.anvil.compiler.daggerModule1
 import com.squareup.anvil.compiler.internal.testing.AnvilCompilationMode
 import com.squareup.anvil.compiler.internal.testing.ComponentProcessingMode
 import com.squareup.anvil.compiler.internal.testing.extends
+import com.squareup.anvil.compiler.internal.testing.originIfMerged
 import com.squareup.anvil.compiler.internal.testing.resolveIfMerged
 import com.squareup.anvil.compiler.internal.testing.shouldNotExtend
 import com.squareup.anvil.compiler.internal.testing.simpleCodeGenerator
@@ -28,34 +29,34 @@ import dagger.Component
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldEndWith
 import org.jetbrains.kotlin.descriptors.runtime.structure.classId
+import org.junit.Assume.assumeFalse
 import org.junit.Assume.assumeTrue
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.runners.Parameterized.Parameters
+import java.lang.reflect.Method
 import javax.inject.Singleton
-import kotlin.io.path.createTempDirectory
 import kotlin.test.assertFailsWith
 
-// @RunWith(Parameterized::class)
+@RunWith(Parameterized::class)
 class ContributesSubcomponentHandlerGeneratorTest(
-  // private val componentProcessingMode: ComponentProcessingMode,
-  // private val mode: AnvilCompilationMode,
+  private val componentProcessingMode: ComponentProcessingMode,
+  private val mode: AnvilCompilationMode,
 ) {
 
-  private val componentProcessingMode: ComponentProcessingMode = ComponentProcessingMode.KSP
-  private val mode: AnvilCompilationMode = AnvilCompilationMode.Ksp()
-
-  // companion object {
-  //   @JvmStatic
-  //   @Parameters(name = "{0} {1}")
-  //   fun parameters(): Collection<Any> {
-  //     return listOf(
-  //       // arrayOf(ComponentProcessingMode.NONE, AnvilCompilationMode.Embedded()),
-  //       arrayOf(ComponentProcessingMode.NONE, AnvilCompilationMode.Ksp()),
-  //       // arrayOf(ComponentProcessingMode.KAPT, AnvilCompilationMode.Embedded()),
-  //       // arrayOf(ComponentProcessingMode.KSP, AnvilCompilationMode.Ksp()),
-  //     )
-  //   }
-  // }
-
+  companion object {
+    @JvmStatic
+    @Parameters(name = "{0} {1}")
+    fun parameters(): Collection<Any> {
+      return listOf(
+        arrayOf(ComponentProcessingMode.NONE, AnvilCompilationMode.Embedded()),
+        arrayOf(ComponentProcessingMode.NONE, AnvilCompilationMode.Ksp()),
+        arrayOf(ComponentProcessingMode.KAPT, AnvilCompilationMode.Embedded()),
+        arrayOf(ComponentProcessingMode.KSP, AnvilCompilationMode.Ksp()),
+      )
+    }
+  }
 
   @Test fun `there is a subcomponent generated for a @MergeComponent`() {
     assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
@@ -85,6 +86,8 @@ class ContributesSubcomponentHandlerGeneratorTest(
 
   @Test fun `generation works for a nested contributed subcomponent with a very long name`() {
     assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
+    // This test tests legacy behavior that we no longer need to do in KSP processing
+    assumeFalse(mode is AnvilCompilationMode.Ksp && componentProcessingMode != ComponentProcessingMode.KSP)
 
     // These name lengths are arbitrary. They're long enough to be somewhat realistic,
     // but short enough that most file names won't become obnoxiously long for no reason.
@@ -601,6 +604,8 @@ class ContributesSubcomponentHandlerGeneratorTest(
   @Test
   fun `there is a parent component interface automatically generated without declaring one explicitly`() {
     assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
+    // This test tests legacy behavior that we no longer need to do in KSP processing
+    assumeFalse(mode is AnvilCompilationMode.Ksp && componentProcessingMode != ComponentProcessingMode.KSP)
     compile(
       """
         package com.squareup.test
@@ -630,6 +635,8 @@ class ContributesSubcomponentHandlerGeneratorTest(
   @Test
   fun `the parent component interface extends a manually declared component interface with the same scope`() {
     assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
+    // This test tests legacy behavior that we no longer need to do in KSP processing
+    assumeFalse(mode is AnvilCompilationMode.Ksp && componentProcessingMode != ComponentProcessingMode.KSP)
     compile(
       """
         package com.squareup.test
@@ -673,6 +680,8 @@ class ContributesSubcomponentHandlerGeneratorTest(
   @Test
   fun `the parent component interface extends a manually declared component interface with the same scope with multiple compilations`() {
     assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
+    // This test tests legacy behavior that we no longer need to do in KSP processing
+    assumeFalse(mode is AnvilCompilationMode.Ksp && componentProcessingMode != ComponentProcessingMode.KSP)
     val firstCompilationResult = compile(
       """
         package com.squareup.test
@@ -816,7 +825,8 @@ class ContributesSubcomponentHandlerGeneratorTest(
 
   @Test
   fun `the parent interface of a contributed subcomponent is picked up by components and other contributed subcomponents`() {
-    val dir = createTempDirectory()
+    // This test tests legacy behavior that we no longer need to do in KSP processing
+    assumeFalse(mode is AnvilCompilationMode.Ksp && componentProcessingMode != ComponentProcessingMode.KSP)
     compile(
       """
         package com.squareup.test
@@ -852,9 +862,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
       mode = mode,
       // Keep Dagger enabled, because it complained initially.
       componentProcessingMode = componentProcessingMode,
-      workingDir = dir.toFile()
     ) {
-
       val anvilComponent1 = subcomponentInterface1.anvilComponent(componentInterface1)
 
       assertThat(componentInterface1)
@@ -1039,6 +1047,8 @@ class ContributesSubcomponentHandlerGeneratorTest(
   @Test
   fun `the parent component interface can return a factory`() {
     assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
+    // This test tests legacy behavior that we no longer need to do in KSP processing
+    assumeFalse(mode is AnvilCompilationMode.Ksp && componentProcessingMode != ComponentProcessingMode.KSP)
     compile(
       """
         package com.squareup.test
@@ -1085,6 +1095,8 @@ class ContributesSubcomponentHandlerGeneratorTest(
   @Test
   fun `a factory can be an abstract class`() {
     assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
+    // This test tests legacy behavior that we no longer need to do in KSP processing
+    assumeFalse(mode is AnvilCompilationMode.Ksp && componentProcessingMode != ComponentProcessingMode.KSP)
     compile(
       """
         package com.squareup.test
@@ -1130,6 +1142,8 @@ class ContributesSubcomponentHandlerGeneratorTest(
 
   @Test fun `the generated parent component interface returns the factory if one is present`() {
     assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
+    // This test tests legacy behavior that we no longer need to do in KSP processing
+    assumeFalse(mode is AnvilCompilationMode.Ksp && componentProcessingMode != ComponentProcessingMode.KSP)
     compile(
       """
         package com.squareup.test
@@ -1219,7 +1233,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
         .invoke(daggerComponent)
 
       val subcomponent = factory::class.java.declaredMethods
-        .single { it.returnType == subcomponentInterface }
+        .getMethodReturningA(subcomponentInterface)
         .use { it.invoke(factory, 5) }
 
       val int = subcomponent::class.java.declaredMethods
@@ -1280,7 +1294,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
         .invoke(testClassInstance)
 
       val subcomponent = factory::class.java.declaredMethods
-        .single { it.returnType == subcomponentInterface }
+        .getMethodReturningA(subcomponentInterface)
         .use { it.invoke(factory, 5) }
 
       val int = subcomponent::class.java.declaredMethods
@@ -1336,7 +1350,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
         .invoke(null)
 
       val subcomponent1 = componentInterface2.methods
-        .single()
+        .getMethodReturningA(componentInterface1)
         .invoke(daggerComponent)
 
       val testClassInstance = componentInterface1.declaredMethods
@@ -1348,7 +1362,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
         .invoke(testClassInstance)
 
       val subcomponent2 = factory::class.java.declaredMethods
-        .single { it.returnType == subcomponentInterface }
+        .getMethodReturningA(subcomponentInterface)
         .use { it.invoke(factory, 5) }
 
       val int = subcomponent2::class.java.declaredMethods
@@ -1364,6 +1378,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
     assumeTrue(componentProcessingMode != ComponentProcessingMode.NONE)
     checkFullTestRun()
 
+    println("Compiling project 1")
     val firstCompilationResult = compile(
       """
         package com.squareup.test
@@ -1405,6 +1420,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
       ).isTrue()
     }
 
+    println("Compiling project 2")
     compile(
       """
         package com.squareup.test
@@ -1429,7 +1445,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
         .invoke(daggerComponent)
 
       val subcomponent = factory::class.java.declaredMethods
-        .single { it.returnType == subcomponentInterface }
+        .getMethodReturningA(subcomponentInterface)
         .use { it.invoke(factory, 5) }
 
       val int = subcomponent::class.java.declaredMethods
@@ -1443,6 +1459,8 @@ class ContributesSubcomponentHandlerGeneratorTest(
   @Test
   fun `the correct generated factory is bound`() {
     assumeTrue(componentProcessingMode == ComponentProcessingMode.NONE)
+    // This test tests legacy behavior that we no longer need to do in KSP processing
+    assumeFalse(mode is AnvilCompilationMode.Ksp && componentProcessingMode != ComponentProcessingMode.KSP)
     compile(
       """
         package com.squareup.test
@@ -1540,7 +1558,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
         .single { it.name == "create" }
         .invoke(null)
 
-      val testClassInstance1 = componentInterface1.declaredMethods
+      val testClassInstance1 = componentInterface1.methods
         .single { it.name == "testClass" }
         .invoke(daggerComponent1)
 
@@ -1548,16 +1566,21 @@ class ContributesSubcomponentHandlerGeneratorTest(
         .single { it.name == "getFactory" }
         .invoke(testClassInstance1)
 
+      val mergedPrefix = if (componentProcessingMode == ComponentProcessingMode.KSP) {
+        "Merged"
+      } else {
+        ""
+      }
       assertThat(factory1::class.java.name)
         .isEqualTo(
-          "com.squareup.test.DaggerComponentInterface1\$SubcomponentInterface_30237c4fFactory",
+          "${componentInterface1.daggerComponent.canonicalName}\$${mergedPrefix}SubcomponentInterface_30237c4fFactory",
         )
 
       val daggerComponent2 = componentInterface2.daggerComponent.declaredMethods
         .single { it.name == "create" }
         .invoke(null)
 
-      val testClassInstance2 = componentInterface2.declaredMethods
+      val testClassInstance2 = componentInterface2.methods
         .single { it.name == "testClass" }
         .invoke(daggerComponent2)
 
@@ -1567,7 +1590,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
 
       assertThat(factory2::class.java.name)
         .isEqualTo(
-          "com.squareup.test.DaggerComponentInterface2\$SubcomponentInterface_42b84d1bFactory",
+          "${componentInterface2.daggerComponent.canonicalName}\$${mergedPrefix}SubcomponentInterface_42b84d1bFactory",
         )
     }
   }
@@ -1682,11 +1705,11 @@ class ContributesSubcomponentHandlerGeneratorTest(
         .invoke(null)
 
       val subcomponent1 = componentInterface1.methods
-        .single()
+        .getMethodReturningA(subcomponentInterface1)
         .invoke(daggerComponent)
 
       val subcomponent2 = subcomponent1::class.java.declaredMethods
-        .single()
+        .getMethodReturningA(subcomponentInterface2)
         .use { it.invoke(subcomponent1) }
 
       val int = subcomponent2::class.java.declaredMethods
@@ -1730,11 +1753,11 @@ class ContributesSubcomponentHandlerGeneratorTest(
         .invoke(null)
 
       val subcomponent1 = componentInterface2.methods
-        .single()
+        .getMethodReturningA(subcomponentInterface1)
         .invoke(daggerComponent)
 
       val subcomponent2 = subcomponent1::class.java.declaredMethods
-        .single()
+        .getMethodReturningA(subcomponentInterface2)
         .use { it.invoke(subcomponent1) }
 
       val int = subcomponent2::class.java.declaredMethods
@@ -2149,9 +2172,9 @@ class ContributesSubcomponentHandlerGeneratorTest(
   // E.g. anvil.component.com.squareup.test.componentinterface.SubcomponentInterfaceA
   private fun Class<*>.anvilComponent(parent: Class<*>): Class<*> {
     return classLoader.loadClass(
-      classId.generatedAnvilSubcomponentClassId(parent.classId)
+      classId.generatedAnvilSubcomponentClassId(parent.originIfMerged().classId)
         .asFqNameString(),
-    )
+    ).resolveIfMerged()
   }
 
   private val Class<*>.anyParentComponentInterface: Class<*>
@@ -2166,6 +2189,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
   private val Class<*>.componentFactory: Class<*>
     get() = classLoader.loadClass("$canonicalName\$ComponentFactory")
 
+  @Suppress("Since15")
   private val Class<*>.daggerComponent: Class<*>
     get() = classLoader.loadClass("$packageName.Dagger$simpleName")
 
@@ -2175,13 +2199,31 @@ class ContributesSubcomponentHandlerGeneratorTest(
 
   private val JvmCompilationResult.componentInterface2: Class<*>
     get() = classLoader.loadClass("com.squareup.test.ComponentInterface2")
+      .resolveIfMerged()
 
   private val JvmCompilationResult.subcomponentInterface1: Class<*>
     get() = classLoader.loadClass("com.squareup.test.SubcomponentInterface1")
+      .resolveIfMerged()
 
   private val JvmCompilationResult.subcomponentInterface2: Class<*>
     get() = classLoader.loadClass("com.squareup.test.SubcomponentInterface2")
+      .resolveIfMerged()
 
   private val JvmCompilationResult.subcomponentInterface3: Class<*>
     get() = classLoader.loadClass("com.squareup.test.SubcomponentInterface3")
+      .resolveIfMerged()
+
+  private fun Array<Method>.getMethodReturningA(clazz: Class<*>): Method {
+    // We may have multiple methods that return the direct class or subtype. In this
+    // scenario, we prefer the direct equals method.
+    return firstOrNull { it.returnType == clazz }
+      ?: firstOrNull { it.returnType.extends(clazz) }
+      ?: throw AssertionError(
+        "Method returning $clazz not found. Available methods are ${
+          joinToString(
+            "\n",
+          )
+        }",
+      )
+  }
 }

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGeneratorTest.kt
@@ -2168,6 +2168,7 @@ class ContributesSubcomponentHandlerGeneratorTest(
 
   private val JvmCompilationResult.componentInterface1: Class<*>
     get() = classLoader.loadClass("com.squareup.test.ComponentInterface1")
+      .resolveIfMerged()
 
   private val JvmCompilationResult.componentInterface2: Class<*>
     get() = classLoader.loadClass("com.squareup.test.ComponentInterface2")


### PR DESCRIPTION
This implements `@ContributesSubcomponent` support in KSP. This is a bit more of an involved process because I've slightly changed the way we generate code for this, plus finished work started in #13.

**High level notes**
- Not every generated `@MergeSubcomponent` contains a parent component. We actually propagate information about the creator factory or contributing interface from the original `@ContributesSubcomponent`-annotated type through the generated subcomponent in a way that is now picked up in the final _merged_ components. This is because the intermediary types ultimately aren't necessary.
- Make `KspContributionMerger` and `KspContributesSubcomponentHandlerSymbolProcessor` cooperative. This allow them to share a single `ClassScannerKsp` and also allow `KspContributionMerger` to intelligently defer rounds based on if there is further processing that needs to be done in `KspContributesSubcomponentHandlerSymbolProcessor` first. This is due to the nature of how we generate merged types in KSP, as we can't assume all current declarations are just going to be modified in place and reference-able.
- Generate dagger binding modules for all merged types that are automatically _included_ by both their merged type _and_ consuming components (i.e. component consuming a subcomponent will also include its binding module). This is important for the merged type behavior.
- More or less preserve backward compatibility, though there are some tests that only run on K1 behavior because of the changed parent component behavior.
- Add some helper metadata annotations in anvil-annotations to help breadcrumb information along.
- All of this should be _source_ compatible when going from K1 to KSP/K2.

**TODO**

- [ ] Take a pass at originating elements. It's trickier with contribution merging but also less relevant since we're aggregating.
- [ ] Second pass at remaining TODOs and possible areas of consolidating logic or optimizing lookups.