### PR TITLE
Only use shallow checks for implicit bound types in bindings

### DIFF
--- a/compiler/src/main/java/com/squareup/anvil/compiler/KspContributionMerger.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/KspContributionMerger.kt
@@ -750,7 +750,7 @@ internal class KspContributionMerger(
 
     if (excludedClasses.isNotEmpty()) {
       val intersect: Set<ClassName> = mergeAnnotatedClass
-        .superTypesExcludingAny(resolver)
+        .superTypesExcludingAny(resolver, shallow = false)
         .mapNotNull { it.resolveKSClassDeclaration()?.toClassName() }
         .toSet()
         // Need to intersect with both merged and origin types to be sure

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/BindsMethodValidator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/BindsMethodValidator.kt
@@ -152,7 +152,7 @@ internal object BindsMethodValidator : AnvilApplicabilityChecker {
 
       private fun KSTypeReference.resolveSuperTypesExcludingAny(): Sequence<KSType> {
         val clazz = resolve().resolveKSClassDeclaration() ?: return emptySequence()
-        return clazz.superTypesExcludingAny(resolver)
+        return clazz.superTypesExcludingAny(resolver, shallow = false)
       }
 
       private fun KSFunctionDeclaration.singleParameterOrNull(): KSTypeReference? =

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ksp/KSAnnotationExtensions.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ksp/KSAnnotationExtensions.kt
@@ -99,7 +99,7 @@ internal fun KSAnnotation.resolveBoundType(
   val declaredBoundType = boundTypeOrNull()?.resolveKSClassDeclaration()
   if (declaredBoundType != null) return declaredBoundType
   // Resolve from the first and only supertype
-  return declaringClass.superTypesExcludingAny(resolver)
+  return declaringClass.superTypesExcludingAny(resolver, shallow = true)
     .single()
     .resolveKSClassDeclaration() ?: throw KspAnvilException(
     message = "Couldn't resolve bound type for ${declaringClass.qualifiedName}",

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesBindingGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesBindingGeneratorTest.kt
@@ -382,6 +382,24 @@ class ContributesBindingGeneratorTest : AnvilCompilationModeTest(
       }
     }
 
+  @TestFactory fun `multiple interfaces in hierarchy for bound types is ok`() =
+    testFactory {
+      compile(
+        """
+      package com.squareup.test
+      
+      import com.squareup.anvil.annotations.ContributesBinding
+
+      interface ParentParentInterface
+      interface ParentInterface : ParentParentInterface
+      
+      @ContributesBinding(Any::class)
+      interface ContributingInterface : ParentInterface
+      """,
+        expectExitCode = OK,
+      )
+    }
+
   @TestFactory fun `the bound type can only be implied with one super type - 2 interfaces`() =
     testFactory {
       compile(

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesMultibindingGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesMultibindingGeneratorTest.kt
@@ -368,6 +368,25 @@ class ContributesMultibindingGeneratorTest : AnvilCompilationModeTest(
       }
     }
 
+  @TestFactory fun `multiple interfaces in hierarchy for bound types is ok`() =
+    testFactory {
+      compile(
+        """
+      package com.squareup.test
+
+      import com.squareup.anvil.annotations.ContributesMultibinding
+
+      interface ParentParentInterface
+      interface ParentInterface : ParentParentInterface
+
+      @ContributesMultibinding(Any::class)
+      interface ContributingInterface : ParentInterface
+      """,
+        mode = mode,
+        expectExitCode = ExitCode.OK,
+      )
+    }
+
   @TestFactory fun `the bound type can only be implied with one super type (2 interfaces)`() =
     testFactory {
       compile(


### PR DESCRIPTION
Previously we were checking all supertypes, which was wrong