### PR TITLE
[ksp] inherit annotated class visibility in merged component

### DIFF
--- a/compiler/src/main/java/com/squareup/anvil/compiler/KspContributionMerger.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/KspContributionMerger.kt
@@ -75,6 +75,7 @@ import com.squareup.kotlinpoet.joinToCode
 import com.squareup.kotlinpoet.ksp.addOriginatingKSFile
 import com.squareup.kotlinpoet.ksp.toAnnotationSpec
 import com.squareup.kotlinpoet.ksp.toClassName
+import com.squareup.kotlinpoet.ksp.toKModifier
 import com.squareup.kotlinpoet.ksp.toTypeName
 import com.squareup.kotlinpoet.ksp.writeTo
 import dagger.Binds
@@ -835,10 +836,14 @@ internal class KspContributionMerger(
     isModule: Boolean,
   ) {
     val mergeAnnotatedClassName = mergeAnnotatedClass.toClassName()
+    val visibility = mergeAnnotatedClass.getVisibility().toKModifier()
     val generatedComponent = TypeSpec.interfaceBuilder(
       generatedComponentClassName.simpleName,
     )
       .apply {
+        visibility?.let {
+          addModifiers(visibility)
+        }
         // Copy over original annotations
         addAnnotations(
           mergeAnnotatedClass.annotations
@@ -1043,6 +1048,11 @@ internal class KspContributionMerger(
         addType(
           TypeSpec.objectBuilder("Dagger${mergeAnnotatedClass.simpleName.asString().capitalize()}")
             .addFunction(creatorFunction)
+            .apply {
+              visibility?.let {
+                addModifiers(visibility)
+              }
+            }
             .build(),
         )
       }

--- a/compiler/src/test/java/com/squareup/anvil/compiler/KspContributionMergerTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/KspContributionMergerTest.kt
@@ -1,9 +1,11 @@
 package com.squareup.anvil.compiler
 
+import com.google.common.truth.Truth.assertThat
 import com.squareup.anvil.compiler.internal.testing.ComponentProcessingMode
 import com.tschuchort.compiletesting.KotlinCompilation
 import org.junit.Assume.assumeTrue
 import org.junit.Test
+import kotlin.reflect.KVisibility
 
 class KspContributionMergerTest {
 
@@ -26,5 +28,26 @@ class KspContributionMergerTest {
       componentProcessingMode = ComponentProcessingMode.KSP,
       expectExitCode = KotlinCompilation.ExitCode.OK,
     )
+  }
+
+  @Test fun `merged component visibility is inherited from annotated class`() {
+    compile(
+      """
+      package com.squareup.test
+      
+      import com.squareup.anvil.annotations.ContributesTo
+      import com.squareup.anvil.annotations.MergeComponent
+      
+      @ContributesTo(Any::class)
+      interface ContributingInterface
+      
+      @MergeComponent(Any::class)
+      internal interface ComponentInterface
+      """,
+      componentProcessingMode = ComponentProcessingMode.KSP,
+    ) {
+      val visibility = componentInterface.kotlin.visibility
+      assertThat(visibility).isEqualTo(KVisibility.INTERNAL)
+    }
   }
 }

--- a/compiler/src/test/java/com/squareup/anvil/compiler/KspContributionMergerTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/KspContributionMergerTest.kt
@@ -31,6 +31,7 @@ class KspContributionMergerTest {
   }
 
   @Test fun `merged component visibility is inherited from annotated class`() {
+    assumeTrue(includeKspTests())
     compile(
       """
       package com.squareup.test


### PR DESCRIPTION
This PR makes sure that generated component uses same visibility as annotated by `@Merge*` one.