### PR TITLE
Make annotation resolution more robust

### DIFF
--- a/compiler/src/main/java/com/squareup/anvil/compiler/ClassScannerKsp.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/ClassScannerKsp.kt
@@ -16,6 +16,7 @@ import com.squareup.anvil.compiler.api.AnvilCompilationException
 import com.squareup.anvil.compiler.codegen.ksp.KspAnvilException
 import com.squareup.anvil.compiler.codegen.ksp.fqName
 import com.squareup.anvil.compiler.codegen.ksp.isInterface
+import com.squareup.anvil.compiler.codegen.ksp.resolvableAnnotations
 import com.squareup.anvil.compiler.codegen.ksp.resolveKSClassDeclaration
 import com.squareup.anvil.compiler.codegen.ksp.returnTypeOrNull
 import com.squareup.anvil.compiler.codegen.ksp.scope
@@ -96,8 +97,8 @@ internal class ClassScannerKsp {
       }
       .filter { clazz ->
         // Check that the annotation really is present. It should always be the case, but it's
-        // a safetynet in case the generated properties are out of sync.
-        clazz.annotations.any {
+        // a safety net in case the generated properties are out of sync.
+        clazz.resolvableAnnotations.any {
           it.annotationType.resolve()
             .toClassName().fqName == annotation && (scope == null || it.scope() == scope)
         }
@@ -173,7 +174,7 @@ internal class ClassScannerKsp {
       .filterIsInstance<KSClassDeclaration>()
       .filter(KSClassDeclaration::isInterface)
       .filter { nestedClass ->
-        nestedClass.annotations
+        nestedClass.resolvableAnnotations
           .any {
             it.fqName == contributesToFqName && (if (parentScopeType != null) it.scope() == parentScopeType else true)
           }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/KspContributionMerger.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/KspContributionMerger.kt
@@ -608,11 +608,11 @@ internal class KspContributionMerger(
           )
         }
 
-        if (annotations[0].annotationType.resolve().toClassName() == mergeComponentClassName) {
+        if (annotations[0].annotationType.resolve().resolveKSClassDeclaration()?.toClassName() == mergeComponentClassName) {
           copyArrayValue("dependencies")
         }
 
-        if (annotations[0].annotationType.resolve().toClassName() == mergeModulesClassName) {
+        if (annotations[0].annotationType.resolve().resolveKSClassDeclaration()?.toClassName() == mergeModulesClassName) {
           copyArrayValue("subcomponents")
         }
       }
@@ -842,6 +842,11 @@ internal class KspContributionMerger(
         // Copy over original annotations
         addAnnotations(
           mergeAnnotatedClass.annotations
+            .filterNot {
+              // Filter out any error types as we don't have a way to handle these
+              // TODO should we maybe just only copy over scope or qualifier annotations?
+              it.annotationType.resolve().isError
+            }
             .map(KSAnnotation::toAnnotationSpec)
             .filterNot {
               it.typeName == mergeComponentClassName ||
@@ -1323,7 +1328,7 @@ private fun KSAnnotation.originClass(): KSClassDeclaration? {
 }
 
 private val KSAnnotation.daggerAnnotationClassName: ClassName
-  get() = when (annotationType.resolve().toClassName()) {
+  get() = when (annotationType.resolve().resolveKSClassDeclaration()?.toClassName()) {
     mergeComponentClassName -> daggerComponentClassName
     mergeSubcomponentClassName -> daggerSubcomponentClassName
     mergeModulesClassName -> daggerModuleClassName

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesMultibindingCodeGen.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesMultibindingCodeGen.kt
@@ -29,6 +29,7 @@ import com.squareup.anvil.compiler.codegen.ksp.ignoreQualifier
 import com.squareup.anvil.compiler.codegen.ksp.isMapKey
 import com.squareup.anvil.compiler.codegen.ksp.qualifierAnnotation
 import com.squareup.anvil.compiler.codegen.ksp.replaces
+import com.squareup.anvil.compiler.codegen.ksp.resolvableAnnotations
 import com.squareup.anvil.compiler.codegen.ksp.resolveBoundType
 import com.squareup.anvil.compiler.codegen.ksp.scope
 import com.squareup.anvil.compiler.contributesMultibindingFqName
@@ -103,7 +104,7 @@ internal object ContributesMultibindingCodeGen : AnvilApplicabilityChecker {
                   Contribution.QualifierData(annotationSpec, key)
                 }
               }
-              val mapKey = clazz.annotations
+              val mapKey = clazz.resolvableAnnotations
                 .filter { it.isMapKey() }
                 .singleOrNull()
                 ?.toAnnotationSpec()

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/KspContributesSubcomponentHandlerSymbolProcessor.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/KspContributesSubcomponentHandlerSymbolProcessor.kt
@@ -31,6 +31,7 @@ import com.squareup.anvil.compiler.codegen.ksp.isInterface
 import com.squareup.anvil.compiler.codegen.ksp.modules
 import com.squareup.anvil.compiler.codegen.ksp.parentScope
 import com.squareup.anvil.compiler.codegen.ksp.replaces
+import com.squareup.anvil.compiler.codegen.ksp.resolvableAnnotations
 import com.squareup.anvil.compiler.codegen.ksp.resolveKSClassDeclaration
 import com.squareup.anvil.compiler.codegen.ksp.returnTypeOrNull
 import com.squareup.anvil.compiler.codegen.ksp.scope
@@ -147,7 +148,7 @@ internal class KspContributesSubcomponentHandlerSymbolProcessor(
                 .build(),
             )
             .addAnnotations(
-              contribution.clazz.annotations
+              contribution.clazz.resolvableAnnotations
                 .filter(KSAnnotation::isDaggerScope)
                 .map(KSAnnotation::toAnnotationSpec)
                 .asIterable(),
@@ -400,7 +401,7 @@ internal class KspContributesSubcomponentHandlerSymbolProcessor(
       )
       .map { clazz ->
         Contribution(
-          annotation = clazz.annotations.single { it.fqName == contributesSubcomponentFqName },
+          annotation = clazz.resolvableAnnotations.single { it.fqName == contributesSubcomponentFqName },
         )
       }
 
@@ -408,7 +409,8 @@ internal class KspContributesSubcomponentHandlerSymbolProcessor(
     replacedReferences += contributions
       .flatMap { contribution ->
         contribution.clazz
-          .annotations.single { it.fqName == contributesSubcomponentFqName }
+          .resolvableAnnotations
+          .single { it.fqName == contributesSubcomponentFqName }
           .replaces()
       }
   }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/DaggerGenerationUtils.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/DaggerGenerationUtils.kt
@@ -18,6 +18,7 @@ import com.squareup.anvil.compiler.codegen.ksp.isAnnotationPresent
 import com.squareup.anvil.compiler.codegen.ksp.isInterface
 import com.squareup.anvil.compiler.codegen.ksp.isLateInit
 import com.squareup.anvil.compiler.codegen.ksp.isQualifier
+import com.squareup.anvil.compiler.codegen.ksp.resolvableAnnotations
 import com.squareup.anvil.compiler.codegen.ksp.resolveKSClassDeclaration
 import com.squareup.anvil.compiler.codegen.ksp.withJvmSuppressWildcardsIfNeeded
 import com.squareup.anvil.compiler.daggerDoubleCheckFqNameString
@@ -515,7 +516,7 @@ private fun KSPropertyDeclaration.toMemberInjectParameter(
     originalName
   }
 
-  val qualifierAnnotations = annotations
+  val qualifierAnnotations = resolvableAnnotations
     .filter { it.isQualifier() }
     .map { it.toAnnotationSpec() }
     .toList()

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ksp/KSAnnotationExtensions.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ksp/KSAnnotationExtensions.kt
@@ -155,7 +155,7 @@ internal fun KSAnnotation.isMapKey(): Boolean = isTypeAnnotatedWith(mapKeyFqName
 internal fun KSAnnotation.isDaggerScope(): Boolean = isTypeAnnotatedWith(daggerScopeFqName)
 
 internal fun KSAnnotated.qualifierAnnotation(): KSAnnotation? =
-  annotations.singleOrNull { it.isQualifier() }
+  resolvableAnnotations.singleOrNull { it.isQualifier() }
 
 internal fun KSAnnotation.ignoreQualifier(): Boolean =
   argumentAt("ignoreQualifier")?.value as? Boolean? == true

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ksp/KSClassDeclarationExtensions.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ksp/KSClassDeclarationExtensions.kt
@@ -13,12 +13,12 @@ import org.jetbrains.kotlin.name.FqName
 internal fun KSClassDeclaration.checkNotMoreThanOneQualifier(
   annotationFqName: FqName,
 ) {
-  val annotationsList = annotations.toList()
+  val annotationsList = resolvableAnnotations.toList()
   // The class is annotated with @ContributesBinding, @ContributesMultibinding, or another Anvil annotation.
   // If there is less than 2 further annotations, then there can't be more than two qualifiers.
   if (annotationsList.size <= 2) return
 
-  val qualifierCount = annotations.count { it.isQualifier() }
+  val qualifierCount = annotationsList.count { it.isQualifier() }
   if (qualifierCount > 1) {
     throw KspAnvilException(
       message = "Classes annotated with @${annotationFqName.shortName()} may not use more " +
@@ -40,7 +40,7 @@ internal inline fun KSClassDeclaration.checkClassIsPublic(message: () -> String)
 internal fun KSClassDeclaration.checkNotMoreThanOneMapKey() {
   // The class is annotated with @ContributesMultibinding. If there is less than 2 further
   // annotations, then there can't be more than two map keys.
-  val annotationsList = annotations.toList()
+  val annotationsList = resolvableAnnotations.toList()
   if (annotationsList.size <= 2) return
 
   val mapKeysCount = annotationsList.count { it.isMapKey() }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ksp/KspUtil.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ksp/KspUtil.kt
@@ -9,12 +9,14 @@ import com.google.devtools.ksp.symbol.ClassKind.ANNOTATION_CLASS
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSAnnotation
 import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSDeclaration
 import com.google.devtools.ksp.symbol.KSFunction
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import com.google.devtools.ksp.symbol.KSModifierListOwner
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSTypeAlias
+import com.google.devtools.ksp.symbol.KSTypeParameter
 import com.google.devtools.ksp.symbol.KSValueParameter
 import com.google.devtools.ksp.symbol.Modifier
 import com.squareup.anvil.compiler.fqName
@@ -44,11 +46,8 @@ import kotlin.reflect.KClass
 internal fun <T : Annotation> KSAnnotated.getKSAnnotationsByType(
   annotationKClass: KClass<T>,
 ): Sequence<KSAnnotation> {
-  return annotations.filter {
-    it.shortName.getShortName() == annotationKClass.simpleName &&
-      it.annotationType.resolve()
-        .declaration.qualifiedName?.asString() == annotationKClass.qualifiedName
-  }
+  val qualifiedName = annotationKClass.qualifiedName ?: return emptySequence()
+  return getKSAnnotationsByQualifiedName(qualifiedName)
 }
 
 /**
@@ -57,11 +56,15 @@ internal fun <T : Annotation> KSAnnotated.getKSAnnotationsByType(
 internal fun KSAnnotated.getKSAnnotationsByQualifiedName(
   qualifiedName: String,
 ): Sequence<KSAnnotation> {
-  val simpleName = qualifiedName.substringAfterLast(".")
   return annotations.filter {
-    it.shortName.getShortName() == simpleName &&
-      it.annotationType.resolve()
-        .declaration.qualifiedName?.asString() == qualifiedName
+    // Don't check the simple name as it could be a typealias
+    val type = it.annotationType.resolve()
+
+    // Ignore error types
+    if (type.isError) return@filter false
+
+    // Resolve the KSClassDeclaration to ensure we peek through typealiases
+    type.resolveKSClassDeclaration()?.qualifiedName?.asString() == qualifiedName
   }
 }
 
@@ -107,12 +110,30 @@ internal fun TypeName.withJvmSuppressWildcardsIfNeeded(
 /**
  * Resolves the [KSClassDeclaration] for this type, including following typealiases as needed.
  */
-internal tailrec fun KSType.resolveKSClassDeclaration(): KSClassDeclaration? {
-  return when (val declaration = declaration) {
+internal fun KSType.resolveKSClassDeclaration(): KSClassDeclaration? =
+  declaration.resolveKSClassDeclaration()
+
+/**
+ * Resolves the [KSClassDeclaration] representation of this declaration, including following
+ * typealiases as needed.
+ *
+ * [KSTypeParameter] types will return null. If you expect one here, you should check the
+ * declaration directly.
+ */
+internal fun KSDeclaration.resolveKSClassDeclaration(): KSClassDeclaration? {
+  return when (val declaration = unwrapTypealiases()) {
     is KSClassDeclaration -> declaration
-    is KSTypeAlias -> declaration.type.resolve().resolveKSClassDeclaration()
-    else -> error("Unrecognized declaration type: $declaration")
+    is KSTypeParameter -> null
+    else -> error("Unexpected declaration type: $this")
   }
+}
+
+/**
+ * Returns the resolved declaration following any typealiases.
+ */
+internal tailrec fun KSDeclaration.unwrapTypealiases(): KSDeclaration = when (this) {
+  is KSTypeAlias -> type.resolve().declaration.unwrapTypealiases()
+  else -> this
 }
 
 /**
@@ -282,6 +303,7 @@ internal fun KSAnnotated.mergeAnnotations(): List<KSAnnotation> {
   )
 }
 
-internal val KSAnnotation.fqName: FqName get() = (annotationType.resolve().declaration as KSClassDeclaration).fqName
+internal val KSAnnotation.fqName: FqName get() =
+  annotationType.resolve().resolveKSClassDeclaration()!!.fqName
 internal val KSType.fqName: FqName get() = resolveKSClassDeclaration()!!.fqName
 internal val KSClassDeclaration.fqName: FqName get() = toClassName().fqName

--- a/compiler/src/test/java/com/squareup/anvil/compiler/KspContributionMergerTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/KspContributionMergerTest.kt
@@ -1,5 +1,8 @@
 package com.squareup.anvil.compiler
 
+import com.google.common.truth.Truth.assertThat
+import com.squareup.anvil.compiler.api.ComponentMergingBackend
+import com.squareup.anvil.compiler.internal.testing.AnvilCompilationMode
 import com.squareup.anvil.compiler.internal.testing.ComponentProcessingMode
 import com.tschuchort.compiletesting.KotlinCompilation
 import org.junit.Assume.assumeTrue
@@ -26,5 +29,59 @@ class KspContributionMergerTest {
       componentProcessingMode = ComponentProcessingMode.KSP,
       expectExitCode = KotlinCompilation.ExitCode.OK,
     )
+  }
+
+  @Test fun `typealiases are followed`() {
+    assumeTrue(includeKspTests())
+    compile(
+      """
+      package com.squareup.test
+      
+      import com.squareup.anvil.annotations.MergeComponent
+
+      typealias CustomMergeComponent = MergeComponent
+      typealias CustomMergeComponentFactory = MergeComponent.Factory
+      
+      @CustomMergeComponent(Any::class)
+      interface ComponentInterface {
+        @CustomMergeComponentFactory
+        interface Factory {
+          fun create(): ComponentInterface
+        }
+      }
+      """,
+      componentProcessingMode = ComponentProcessingMode.KSP,
+      expectExitCode = KotlinCompilation.ExitCode.OK,
+    ) {
+      assertThat(componentInterface.canonicalName).isEqualTo("com.squareup.test.MergedComponentInterface")
+      // Ensure we saw and generated the factory creator too
+      assertThat(classLoader.loadClass("${componentInterface.canonicalName}\$Factory").canonicalName)
+        .isEqualTo("com.squareup.test.MergedComponentInterface.Factory")
+    }
+  }
+
+  @Test fun `error type annotations are ignored`() {
+    assumeTrue(includeKspTests())
+    compile(
+      """
+      package com.squareup.test
+      
+      import com.squareup.anvil.annotations.MergeComponent
+      import fake.DoesNotExist
+
+      @DoesNotExist
+      @MergeComponent(Any::class)
+      interface ComponentInterface
+      """,
+      componentProcessingMode = ComponentProcessingMode.NONE,
+      componentMergingBackend = ComponentMergingBackend.KSP,
+      expectExitCode = KotlinCompilation.ExitCode.COMPILATION_ERROR,
+    ) {
+      // Assert that we generated a merged component
+      val mergedComponent = walkGeneratedFiles(AnvilCompilationMode.Ksp())
+        .single { it.name == "MergedComponentInterface.kt" }
+      assertThat(mergedComponent).isNotNull()
+      assertThat(mergedComponent.readText()).doesNotContain("DoesNotExist")
+    }
   }
 }

--- a/compiler/src/test/java/com/squareup/anvil/compiler/KspContributionMergerTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/KspContributionMergerTest.kt
@@ -61,15 +61,19 @@ class KspContributionMergerTest {
       package com.squareup.test
       
       import com.squareup.anvil.annotations.MergeComponent
+      import dagger.BindsInstance
 
       typealias CustomMergeComponent = MergeComponent
       typealias CustomMergeComponentFactory = MergeComponent.Factory
+      typealias CustomBindsInstance = BindsInstance
       
       @CustomMergeComponent(Any::class)
       interface ComponentInterface {
+        fun value(): Int
+        
         @CustomMergeComponentFactory
         interface Factory {
-          fun create(): ComponentInterface
+          fun create(@CustomBindsInstance value: Int): ComponentInterface
         }
       }
       """,
@@ -98,7 +102,13 @@ class KspContributionMergerTest {
 
       @DoesNotExist
       @MergeComponent(Any::class)
-      interface ComponentInterface
+      interface ComponentInterface {
+        @DoesNotExist
+        @MergeComponent.Factory
+        interface Factory {
+          fun create(): ComponentInterface
+        }
+      }
       """,
       componentProcessingMode = ComponentProcessingMode.NONE,
       componentMergingBackend = ComponentMergingBackend.KSP,

--- a/compiler/src/test/java/com/squareup/anvil/compiler/KspContributionMergerTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/KspContributionMergerTest.kt
@@ -53,9 +53,13 @@ class KspContributionMergerTest {
       componentProcessingMode = ComponentProcessingMode.KSP,
       expectExitCode = KotlinCompilation.ExitCode.OK,
     ) {
-      assertThat(componentInterface.canonicalName).isEqualTo("com.squareup.test.MergedComponentInterface")
+      assertThat(
+        componentInterface.canonicalName,
+      ).isEqualTo("com.squareup.test.MergedComponentInterface")
       // Ensure we saw and generated the factory creator too
-      assertThat(classLoader.loadClass("${componentInterface.canonicalName}\$Factory").canonicalName)
+      assertThat(
+        classLoader.loadClass("${componentInterface.canonicalName}\$Factory").canonicalName,
+      )
         .isEqualTo("com.squareup.test.MergedComponentInterface.Factory")
     }
   }


### PR DESCRIPTION
Resolves #32 by ignoring error types when searching and copying annotations

Resolves #24 by resolving declaration through typealiases