### PR TITLE
Fix handling of contributed subcomponent factory modules

### DIFF
--- a/compiler/src/main/java/com/squareup/anvil/compiler/ClassScannerKsp.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/ClassScannerKsp.kt
@@ -13,13 +13,17 @@ import com.google.devtools.ksp.symbol.Visibility
 import com.squareup.anvil.compiler.ClassScannerKsp.GeneratedProperty.ReferenceProperty
 import com.squareup.anvil.compiler.ClassScannerKsp.GeneratedProperty.ScopeProperty
 import com.squareup.anvil.compiler.api.AnvilCompilationException
+import com.squareup.anvil.compiler.codegen.ksp.KSCallable
 import com.squareup.anvil.compiler.codegen.ksp.KspAnvilException
 import com.squareup.anvil.compiler.codegen.ksp.fqName
+import com.squareup.anvil.compiler.codegen.ksp.getAllCallables
+import com.squareup.anvil.compiler.codegen.ksp.isAbstract
 import com.squareup.anvil.compiler.codegen.ksp.isInterface
 import com.squareup.anvil.compiler.codegen.ksp.resolvableAnnotations
 import com.squareup.anvil.compiler.codegen.ksp.resolveKSClassDeclaration
 import com.squareup.anvil.compiler.codegen.ksp.returnTypeOrNull
 import com.squareup.anvil.compiler.codegen.ksp.scope
+import com.squareup.anvil.compiler.codegen.ksp.type
 import com.squareup.kotlinpoet.ksp.toClassName
 import org.jetbrains.kotlin.name.FqName
 
@@ -27,8 +31,8 @@ internal class ClassScannerKsp {
 
   private val generatedPropertyCache = mutableMapOf<CacheKey, Collection<List<GeneratedProperty>>>()
   private val parentComponentCache = mutableMapOf<FqName, KSClassDeclaration?>()
-  private val overridableParentComponentFunctionCache =
-    mutableMapOf<FqName, List<KSFunctionDeclaration>>()
+  private val overridableParentComponentCallableCache =
+    mutableMapOf<FqName, List<KSCallable>>()
 
   /**
    * Externally-contributed contributions, which are important to track so that we don't try to
@@ -159,7 +163,7 @@ internal class ClassScannerKsp {
    */
   fun findParentComponentInterface(
     componentClass: KSClassDeclaration,
-    factoryClass: KSClassDeclaration?,
+    creatorClass: KSClassDeclaration?,
     parentScopeType: KSType?,
   ): KSClassDeclaration? {
     val fqName = componentClass.fqName
@@ -182,7 +186,7 @@ internal class ClassScannerKsp {
       .toList()
 
     val componentInterface = when (contributedInnerComponentInterfaces.size) {
-      0 -> return null
+      0 -> return null // TODO cache
       1 -> contributedInnerComponentInterfaces[0]
       else -> throw KspAnvilException(
         node = componentClass,
@@ -191,14 +195,14 @@ internal class ClassScannerKsp {
       )
     }
 
-    val functions = overridableParentComponentFunctions(
+    val callables = overridableParentComponentCallables(
       componentInterface,
       componentClass.fqName,
-      factoryClass?.fqName,
+      creatorClass?.fqName,
     )
 
-    when (functions.count()) {
-      0 -> return null
+    when (callables.count()) {
+      0 -> return null // TODO cache
       1 -> {
         // This is ok
       }
@@ -214,30 +218,30 @@ internal class ClassScannerKsp {
   }
 
   /**
-   * Returns a list of overridable parent component functions from a given [parentComponent]
-   * for the given [targetReturnType].
+   * Returns a list of overridable parent component callables from a given [parentComponent]
+   * for the given [targetReturnType]. This can include both functions and properties.
    */
-  fun overridableParentComponentFunctions(
+  fun overridableParentComponentCallables(
     parentComponent: KSClassDeclaration,
     targetReturnType: FqName,
-    factoryClass: FqName?,
-  ): List<KSFunctionDeclaration> {
+    creatorClass: FqName?,
+  ): List<KSCallable> {
     val fqName = parentComponent.fqName
 
     // Can't use getOrPut because it doesn't differentiate between absent and null
-    if (fqName in overridableParentComponentFunctionCache) {
-      return overridableParentComponentFunctionCache.getValue(fqName)
+    if (fqName in overridableParentComponentCallableCache) {
+      return overridableParentComponentCallableCache.getValue(fqName)
     }
 
-    return parentComponent.getAllFunctions()
+    return parentComponent.getAllCallables()
       .filter { it.isAbstract && it.getVisibility() == Visibility.PUBLIC }
       .filter {
-        val returnType = it.returnTypeOrNull()?.resolveKSClassDeclaration() ?: return@filter false
-        returnType.fqName == targetReturnType || (factoryClass != null && returnType.fqName == factoryClass)
+        val type = it.type?.resolveKSClassDeclaration()?.fqName ?: return@filter false
+        type == targetReturnType || (creatorClass != null && type == creatorClass)
       }
       .toList()
       .also {
-        overridableParentComponentFunctionCache[fqName] = it
+        overridableParentComponentCallableCache[fqName] = it
       }
   }
 }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/ClassScannerKsp.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/ClassScannerKsp.kt
@@ -4,7 +4,6 @@ import com.google.devtools.ksp.KspExperimental
 import com.google.devtools.ksp.getVisibility
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSClassDeclaration
-import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSTypeReference
@@ -21,7 +20,6 @@ import com.squareup.anvil.compiler.codegen.ksp.isAbstract
 import com.squareup.anvil.compiler.codegen.ksp.isInterface
 import com.squareup.anvil.compiler.codegen.ksp.resolvableAnnotations
 import com.squareup.anvil.compiler.codegen.ksp.resolveKSClassDeclaration
-import com.squareup.anvil.compiler.codegen.ksp.returnTypeOrNull
 import com.squareup.anvil.compiler.codegen.ksp.scope
 import com.squareup.anvil.compiler.codegen.ksp.type
 import com.squareup.kotlinpoet.ksp.toClassName

--- a/compiler/src/main/java/com/squareup/anvil/compiler/KspContributionMerger.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/KspContributionMerger.kt
@@ -9,7 +9,6 @@ import com.google.devtools.ksp.symbol.ClassKind
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSAnnotation
 import com.google.devtools.ksp.symbol.KSClassDeclaration
-import com.google.devtools.ksp.symbol.KSDeclaration
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import com.google.devtools.ksp.symbol.KSName
 import com.google.devtools.ksp.symbol.KSNode
@@ -90,7 +89,6 @@ import dagger.Module
 import dagger.Subcomponent
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
-import java.util.Objects
 import kotlin.reflect.KClass
 
 /**
@@ -271,7 +269,7 @@ internal class KspContributionMerger(
         contributedSubcomponentData = contributedSubcomponentData,
         originatingDeclarations = originatingDeclarations,
         mergeAnnotatedClass = mergeAnnotatedClass,
-        generatedComponentClassName = generatedComponentClassName
+        generatedComponentClassName = generatedComponentClassName,
       )
     }
 
@@ -998,9 +996,11 @@ internal class KspContributionMerger(
                 declaration.toPropertySpec()
                   .toBuilder()
                   .addModifiers(OVERRIDE)
-                  .getter(FunSpec.getterBuilder()
-                    .addStatement("return %L", body)
-                    .build())
+                  .getter(
+                    FunSpec.getterBuilder()
+                      .addStatement("return %L", body)
+                      .build(),
+                  )
                   .build(),
               )
             }
@@ -1480,7 +1480,7 @@ private fun Creator.extend(
     ClassKind.ENUM_ENTRY,
     ClassKind.OBJECT,
     ClassKind.ANNOTATION_CLASS,
-      -> throw KspAnvilException(
+    -> throw KspAnvilException(
       node = declaration,
       message = "Unsupported class kind: ${declaration.classKind}",
     )

--- a/compiler/src/main/java/com/squareup/anvil/compiler/KspContributionMerger.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/KspContributionMerger.kt
@@ -981,10 +981,10 @@ internal class KspContributionMerger(
 
           // Manually override and implement these original declaration to point at their
           // contributed parent components instead
-          when (declaration) {
+          when (val decl = declaration.originalDeclaration) {
             is KSFunctionDeclaration -> {
               addFunction(
-                declaration.toFunSpec()
+                decl.toFunSpec()
                   .toBuilder()
                   .addModifiers(OVERRIDE)
                   .addStatement("return %L", body)
@@ -993,7 +993,7 @@ internal class KspContributionMerger(
             }
             is KSPropertyDeclaration -> {
               addProperty(
-                declaration.toPropertySpec()
+                decl.toPropertySpec()
                   .toBuilder()
                   .addModifiers(OVERRIDE)
                   .getter(

--- a/compiler/src/main/java/com/squareup/anvil/compiler/Utils.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/Utils.kt
@@ -51,7 +51,8 @@ internal val contributesBindingFqName = ContributesBinding::class.fqName
 internal val contributesMultibindingFqName = ContributesMultibinding::class.fqName
 internal val contributesSubcomponentFqName = ContributesSubcomponent::class.fqName
 internal val contributesSubcomponentFactoryFqName = ContributesSubcomponent.Factory::class.fqName
-internal val contributesSubcomponentFactoryClassName = ContributesSubcomponent.Factory::class.asClassName()
+internal val contributesSubcomponentFactoryClassName =
+  ContributesSubcomponent.Factory::class.asClassName()
 internal val internalBindingMarkerFqName = InternalBindingMarker::class.fqName
 internal val daggerComponentFqName = Component::class.fqName
 internal val daggerComponentFactoryFqName = Component.Factory::class.fqName
@@ -185,6 +186,10 @@ internal inline fun <T, R> Array<T>.mapToSet(
   return mapTo(destination, transform)
 }
 
-internal val ClassName.fqName: FqName get() {
-  return FqName(canonicalName)
-}
+internal val ClassName.fqName: FqName
+  get() {
+    return FqName(canonicalName)
+  }
+
+internal inline fun <T, C : Collection<T>, O> C.ifNotEmpty(body: (C) -> O?): O? =
+  if (isNotEmpty()) body(this) else null

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ksp/KSCallable.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ksp/KSCallable.kt
@@ -1,0 +1,43 @@
+package com.squareup.anvil.compiler.codegen.ksp
+
+import com.google.devtools.ksp.isAbstract
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSDeclaration
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import com.google.devtools.ksp.symbol.KSPropertyDeclaration
+import com.google.devtools.ksp.symbol.KSType
+
+/**
+ * Abstraction over [KSFunctionDeclaration] and [KSPropertyDeclaration].
+ */
+internal sealed class KSCallable(
+  declaration: KSDeclaration
+) : KSDeclaration by declaration {
+
+  val originalDeclaration = declaration
+
+  data class Function(val declaration: KSFunctionDeclaration) : KSCallable(declaration)
+
+  data class Property(val declaration: KSPropertyDeclaration) : KSCallable(declaration)
+}
+
+internal val KSCallable.type: KSType?
+  get() = when (this) {
+    is KSCallable.Function -> declaration.returnType?.resolve()
+    is KSCallable.Property -> declaration.type.resolve()
+  }
+
+internal val KSCallable.isAbstract: Boolean
+  get() = when (this) {
+    is KSCallable.Function -> declaration.isAbstract
+    is KSCallable.Property -> declaration.isAbstract()
+  }
+
+internal fun KSPropertyDeclaration.asKSCallable(): KSCallable.Property = KSCallable.Property(this)
+internal fun KSFunctionDeclaration.asKSCallable(): KSCallable.Function = KSCallable.Function(this)
+
+internal fun KSClassDeclaration.getAllCallables(): Sequence<KSCallable> {
+  val functions = getAllFunctions().map { it.asKSCallable() }
+  val properties = getAllProperties().map { it.asKSCallable() }
+  return functions + properties
+}

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ksp/KSCallable.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ksp/KSCallable.kt
@@ -11,7 +11,7 @@ import com.google.devtools.ksp.symbol.KSType
  * Abstraction over [KSFunctionDeclaration] and [KSPropertyDeclaration].
  */
 internal sealed class KSCallable(
-  declaration: KSDeclaration
+  declaration: KSDeclaration,
 ) : KSDeclaration by declaration {
 
   val originalDeclaration = declaration

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ksp/KspUtil.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ksp/KspUtil.kt
@@ -285,8 +285,10 @@ internal fun KSFunctionDeclaration.toFunSpec(): FunSpec {
   return builder.build()
 }
 
-internal fun KSPropertyDeclaration.toPropertySpec(): PropertySpec {
-  return PropertySpec.builder(simpleName.getShortName(), type.resolve().toTypeName())
+internal fun KSPropertyDeclaration.toPropertySpec(
+  typeOverride: TypeName = type.resolve().toTypeName(),
+): PropertySpec {
+  return PropertySpec.builder(simpleName.getShortName(), typeOverride)
     .addModifiers(modifiers.mapNotNull { it.toKModifier() })
     .addAnnotations(
       resolvableAnnotations.map { it.toAnnotationSpec() }.asIterable(),

--- a/compiler/src/test/java/com/squareup/anvil/compiler/KspContributionMergerTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/KspContributionMergerTest.kt
@@ -170,7 +170,9 @@ class KspContributionMergerTest {
       """,
       componentProcessingMode = ComponentProcessingMode.KSP,
     ) {
-      val test = classLoader.loadClass("com.squareup.test.Test").getDeclaredMethod("test", String::class.java)
+      val test = classLoader.loadClass(
+        "com.squareup.test.Test",
+      ).getDeclaredMethod("test", String::class.java)
       val input = "Hello, world!"
       val output = test.invoke(null, "Hello, world!")
       assertThat(output).isEqualTo(input)

--- a/compiler/src/test/java/com/squareup/anvil/compiler/KspContributionMergerTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/KspContributionMergerTest.kt
@@ -6,13 +6,18 @@ import com.squareup.anvil.compiler.internal.testing.AnvilCompilationMode
 import com.squareup.anvil.compiler.internal.testing.ComponentProcessingMode
 import com.tschuchort.compiletesting.KotlinCompilation
 import org.junit.Assume.assumeTrue
+import org.junit.Before
 import org.junit.Test
 import kotlin.reflect.KVisibility
 
 class KspContributionMergerTest {
 
-  @Test fun `creator-less components still generate a shim`() {
+  @Before
+  fun setup() {
     assumeTrue(includeKspTests())
+  }
+
+  @Test fun `creator-less components still generate a shim`() {
     compile(
       """
       package com.squareup.test
@@ -33,7 +38,6 @@ class KspContributionMergerTest {
   }
 
   @Test fun `merged component visibility is inherited from annotated class`() {
-    assumeTrue(includeKspTests())
     compile(
       """
       package com.squareup.test
@@ -55,7 +59,6 @@ class KspContributionMergerTest {
   }
 
   @Test fun `typealiases are followed`() {
-    assumeTrue(includeKspTests())
     compile(
       """
       package com.squareup.test
@@ -92,7 +95,6 @@ class KspContributionMergerTest {
   }
 
   @Test fun `error type annotations are ignored`() {
-    assumeTrue(includeKspTests())
     compile(
       """
       package com.squareup.test
@@ -119,6 +121,62 @@ class KspContributionMergerTest {
         .single { it.name == "MergedComponentInterface.kt" }
       assertThat(mergedComponent).isNotNull()
       assertThat(mergedComponent.readText()).doesNotContain("DoesNotExist")
+    }
+  }
+
+  @Test fun `factory contributors are picked up`() {
+    compile(
+      """
+      package com.squareup.test
+      
+      import com.squareup.anvil.annotations.MergeComponent
+      import com.squareup.anvil.annotations.MergeSubcomponent
+      import com.squareup.anvil.annotations.ContributesTo
+      import com.squareup.anvil.annotations.optional.SingleIn
+      import dagger.BindsInstance
+
+      abstract class AppScope private constructor()
+      abstract class UserScope private constructor()
+
+      @SingleIn(AppScope::class)
+      @MergeComponent(AppScope::class)
+      interface AppComponent {
+        @MergeComponent.Factory
+        interface Factory {
+          fun create(
+            @BindsInstance value: Int,
+          ): AppComponent
+        }
+      }
+
+      @SingleIn(UserScope::class)
+      @MergeSubcomponent(UserScope::class)
+      interface UserComponent {
+      
+        val value: Int
+      
+        @ContributesTo(AppScope::class)
+        interface Parent {
+          val userComponentFactory: Factory
+        }
+      
+        @MergeSubcomponent.Factory
+        interface Factory {
+          fun create(): UserComponent
+        }
+      }
+
+      fun caller() {
+        val parent = DaggerAppComponent.factory().create(5) as UserComponent.Parent
+        val userComponent = parent.userComponentFactory.create()
+      }
+      """,
+      componentProcessingMode = ComponentProcessingMode.KSP,
+    ) {
+      // TODO assert we can get an instance of the UserComponent
+      walkGeneratedFiles(AnvilCompilationMode.Ksp()).forEach {
+        println(it.readText())
+      }
     }
   }
 }


### PR DESCRIPTION
This resolves the issue revealed by https://github.com/r0adkll/anvil-ic-bug-repro (ignore the name, recycled repro repo). This ensures we include subcomponent factory binding modules + adds support for property getters on contributed parent component interfaces