### PR TITLE
Allow component merging even if generating factories

### DIFF
--- a/compiler/src/main/java/com/squareup/anvil/compiler/ClassScanningKspProcessor.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/ClassScanningKspProcessor.kt
@@ -48,7 +48,6 @@ internal class ClassScanningKspProcessor(
 
       val componentMergingEnabled =
         !context.disableComponentMerging &&
-          !context.generateFactories &&
           context.componentMergingBackend == ComponentMergingBackend.KSP
 
       val delegates = if (componentMergingEnabled) {


### PR DESCRIPTION
Ported this logic wrong, this is actually an allowable case. For example - someone could merge a subcomponent and generate factories in a module _without_ actually running any component merging