### PR TITLE
Introduce AnvilKspOptionsProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 **Unreleased**
 --------------
 
+- **Fix:** Correctly track inputs to KSP command line options so they don't result in incorrect task build cache hits.
+
 0.2.1
 -----
 


### PR DESCRIPTION
In order for `CommandLineArgumentProvider` to work correctly, it needs to internally track its inputs as a managed object. Prior to this, changes to providers would not actually invalidate a KSP task's inputs and result in incorrect cache hits since the pluginOptions themselves under the hood are deemed internal and ignored.

This fixes it by creating a new `AnvilKspOptionsProvider` managed type with a `MapProperty` that tracks the inputs. This is appropriately wired in `KspTask` as a `@Nested` input, which then fixes this cache hit issue.