### PR TITLE
Fix init order in AnvilExtension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 --------------
 
 - **Fix:** Correctly track inputs to KSP command line options so they don't result in incorrect task build cache hits.
+- **Fix:** Don't set default AnvilExtension property values until after all properties are initialized.
 
 0.2.1
 -----

--- a/gradle-plugin/src/main/java/com/squareup/anvil/plugin/AnvilExtension.kt
+++ b/gradle-plugin/src/main/java/com/squareup/anvil/plugin/AnvilExtension.kt
@@ -25,20 +25,6 @@ public abstract class AnvilExtension @Inject constructor(
   private val providers: ProviderFactory,
 ) {
 
-  init {
-    val useKspBackend = providers.gradleProperty("com.squareup.anvil.useKspBackend")
-      .map { it.toBoolean() }
-      .getOrElse(false)
-    val useKspComponentMergingBackend = providers.gradleProperty(
-      "com.squareup.anvil.useKspComponentMergingBackend",
-    )
-      .map { it.toBoolean() }
-      .getOrElse(false)
-    if (useKspBackend || useKspComponentMergingBackend) {
-      useKsp(useKspBackend, useKspComponentMergingBackend)
-    }
-  }
-
   /**
    * Allows you to use Anvil to generate Factory classes that usually the Dagger annotation
    * processor would generate for `@Provides` methods, `@Inject` constructors and `@Inject` fields.
@@ -170,6 +156,20 @@ public abstract class AnvilExtension @Inject constructor(
         .map { it.splitToSequence(":").filterNot { it.isBlank() }.toSet() }
         .orElse(emptySet()),
     )
+
+  init {
+    val useKspBackend = providers.gradleProperty("com.squareup.anvil.useKspBackend")
+      .map { it.toBoolean() }
+      .getOrElse(false)
+    val useKspComponentMergingBackend = providers.gradleProperty(
+      "com.squareup.anvil.useKspComponentMergingBackend",
+    )
+      .map { it.toBoolean() }
+      .getOrElse(false)
+    if (useKspBackend || useKspComponentMergingBackend) {
+      useKsp(useKspBackend, useKspComponentMergingBackend)
+    }
+  }
 
   /**
    * Enables the new [KSP](https://github.com/google/ksp) backends for Anvil. Note that this


### PR DESCRIPTION
These properties are getting set before they're actually initialized