### PR TITLE
Strip ABSTRACT modifiers if present when overriding component returning functions

### DIFF
--- a/compiler/src/main/java/com/squareup/anvil/compiler/KspContributionMerger.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/KspContributionMerger.kt
@@ -1023,6 +1023,10 @@ internal class KspContributionMerger(
                 decl.toFunSpec()
                   .toBuilder()
                   .addModifiers(OVERRIDE)
+                  .apply {
+                    // We're adding a body so remove ABSTRACT if present
+                    modifiers.remove(ABSTRACT)
+                  }
                   .addStatement("return %L", body)
                   .build(),
               )
@@ -1032,6 +1036,10 @@ internal class KspContributionMerger(
                 decl.toPropertySpec()
                   .toBuilder()
                   .addModifiers(OVERRIDE)
+                  .apply {
+                    // We're adding a body so remove ABSTRACT if present
+                    modifiers.remove(ABSTRACT)
+                  }
                   .getter(
                     FunSpec.getterBuilder()
                       .addStatement("return %L", body)


### PR DESCRIPTION
I think KSP adds these modifiers when it's an inherited function from a superinterface