### PR TITLE
Source extension supportedAnnotationTypes in contribution merging when deciding when to defer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 **Unreleased**
 --------------
 
+- Source `AnvilKspExtension.supportedAnnotationTypes` in contribution merging when deciding when to defer.
+
 0.2.4
 -----
 

--- a/compiler/src/main/java/com/squareup/anvil/compiler/KspContributionMerger.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/KspContributionMerger.kt
@@ -139,6 +139,7 @@ internal class KspContributionMerger(
         addAll(it.splitToSequence(':').filterNot(String::isBlank))
       }
     }
+    addAll(extensions.flatMap { it.supportedAnnotationTypes })
     // contributesSubcomponentFqName is handled uniquely
   }.filterNotTo(mutableSetOf()) { it in MERGE_ANNOTATION_NAMES }
 


### PR DESCRIPTION
Forgot to wire this up before. Still need to tackle a larger integration test for this, but this will cover things for now.