### PR TITLE
Report location of code causing KSP exceptions when generating assisted factories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 --------------
 
 - **Enhancement**: Report more context for error types, such as the name of the parameter it came from.
+- **Fix**: For generic types, check for error types in their type arguments as well.
 
 0.3.1
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 **Unreleased**
 --------------
 
+- **Enhancement**: Report more context for error types, such as the name of the parameter it came from.
+
 0.3.1
 -----
 

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/DaggerGenerationUtils.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/DaggerGenerationUtils.kt
@@ -5,7 +5,6 @@ import com.google.devtools.ksp.getAllSuperTypes
 import com.google.devtools.ksp.getAnnotationsByType
 import com.google.devtools.ksp.getDeclaredProperties
 import com.google.devtools.ksp.getVisibility
-import com.google.devtools.ksp.symbol.FileLocation
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
@@ -139,7 +138,7 @@ private fun KSValueParameter.toConstructorParameter(
 ): ConstructorParameter? {
   val type = type.resolve()
   if (type.isError) return null
-  val paramTypeName = reportLocationOnError { type.contextualToTypeName(this, typeParameterResolver) }
+  val paramTypeName = type.contextualToTypeName(this, typeParameterResolver)
   val rawType = paramTypeName.requireRawType()
 
   val isWrappedInProvider = rawType == providerClassName
@@ -609,20 +608,6 @@ internal fun assertNoDuplicateFunctions(
       node = declaringClass,
       message = "Cannot have more than one binding method with the same name in " +
         "a single module: ${duplicateFunctions.keys.joinToString()}",
-    )
-  }
-}
-
-private fun <D : KSValueParameter, T> D.reportLocationOnError(block: () -> T): T {
-  return try {
-    block()
-  } catch (e: Exception) {
-    val name = name?.asString() ?: "unknown"
-    val locationDescription = (location as? FileLocation)?.let {
-      "${it.filePath}:${it.lineNumber}"
-    } ?: "unknown location"
-    throw IllegalArgumentException(
-      "Failed to resolve type for parameter '$name' at $locationDescription", e
     )
   }
 }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/DaggerGenerationUtils.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/DaggerGenerationUtils.kt
@@ -5,6 +5,7 @@ import com.google.devtools.ksp.getAllSuperTypes
 import com.google.devtools.ksp.getAnnotationsByType
 import com.google.devtools.ksp.getDeclaredProperties
 import com.google.devtools.ksp.getVisibility
+import com.google.devtools.ksp.symbol.FileLocation
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
@@ -138,7 +139,7 @@ private fun KSValueParameter.toConstructorParameter(
 ): ConstructorParameter? {
   val type = type.resolve()
   if (type.isError) return null
-  val paramTypeName = type.contextualToTypeName(this, typeParameterResolver)
+  val paramTypeName = reportLocationOnError { type.contextualToTypeName(this, typeParameterResolver) }
   val rawType = paramTypeName.requireRawType()
 
   val isWrappedInProvider = rawType == providerClassName
@@ -608,6 +609,20 @@ internal fun assertNoDuplicateFunctions(
       node = declaringClass,
       message = "Cannot have more than one binding method with the same name in " +
         "a single module: ${duplicateFunctions.keys.joinToString()}",
+    )
+  }
+}
+
+private fun <D : KSValueParameter, T> D.reportLocationOnError(block: () -> T): T {
+  return try {
+    block()
+  } catch (e: Exception) {
+    val name = name?.asString() ?: "unknown"
+    val locationDescription = (location as? FileLocation)?.let {
+      "${it.filePath}:${it.lineNumber}"
+    } ?: "unknown location"
+    throw IllegalArgumentException(
+      "Failed to resolve type for parameter '$name' at $locationDescription", e
     )
   }
 }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ksp/KspUtil.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ksp/KspUtil.kt
@@ -386,16 +386,18 @@ internal fun KSType.contextualToClassName(origin: KSNode): ClassName {
 }
 
 private fun KSType.checkErrorType(origin: KSNode) {
-  val errorType = if (isError) {
-    origin
+  val errorTypeDescription = if (isError) {
+    origin.toString()
   } else {
     arguments.asSequence().mapNotNull {
       it.type?.resolve()
-    }.firstOrNull { it.isError }
+    }.firstOrNull { it.isError }?.toString()
   }
-  if (errorType != null) {
+  if (errorTypeDescription != null) {
     val message = buildString {
-      append("Error type '$errorType' is not resolvable in the current round of processing. ")
+      append(
+        "Error type '$errorTypeDescription' is not resolvable in the current round of processing. ",
+      )
       when (origin) {
         is KSValueParameter -> {
           append(

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ksp/KspUtil.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ksp/KspUtil.kt
@@ -386,22 +386,34 @@ internal fun KSType.contextualToClassName(origin: KSNode): ClassName {
 }
 
 private fun KSType.checkErrorType(origin: KSNode) {
-  val errorType = if (isError) origin else arguments.asSequence().mapNotNull { it.type?.resolve() }.firstOrNull { it.isError }
+  val errorType = if (isError) {
+    origin
+  } else {
+    arguments.asSequence().mapNotNull {
+      it.type?.resolve()
+    }.firstOrNull { it.isError }
+  }
   if (errorType != null) {
     val message = buildString {
       append("Error type '$errorType' is not resolvable in the current round of processing. ")
       when (origin) {
         is KSValueParameter -> {
-          append("This happened for parameter '${origin.name?.asString()} : ${origin.type.resolve()}'. ")
+          append(
+            "This happened for parameter '${origin.name?.asString()} : ${origin.type.resolve()}'. ",
+          )
         }
         is KSPropertyDeclaration -> {
-          append("This happened for property '${origin.simpleName.getShortName()} : ${origin.type.resolve()}'. ")
+          append(
+            "This happened for property '${origin.simpleName.getShortName()} : ${origin.type.resolve()}'. ",
+          )
         }
         is KSFunctionDeclaration -> {
           append("This happened for function '${origin.simpleName.getShortName()}'. ")
         }
       }
-      append("Check your imports or, if this is a generated type, ensure the tool that generates it has its outputs appropriately sources as inputs to the KSP task.")
+      append(
+        "Check your imports or, if this is a generated type, ensure the tool that generates it has its outputs appropriately sources as inputs to the KSP task.",
+      )
     }
     throw KspAnvilException(message = message, node = origin)
   }

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/AssistedFactoryGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/AssistedFactoryGeneratorTest.kt
@@ -2212,8 +2212,9 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
       ) {
         val lines = messages.split("\n")
         val exceptionLine =
-          lines.find { it.contains("Failed to resolve type for parameter 'strings'") }
+          lines.find { it.contains("Error type '<ERROR TYPE>' is not resolvable in the current round of processing") }
         assertThat(exceptionLine).isNotNull()
+        assertThat(exceptionLine).contains("strings : List<[Error type: Unresolved type for Foo]>")
         assertThat(exceptionLine).contains(".kt:10")
       }
     }

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/AssistedFactoryGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/AssistedFactoryGeneratorTest.kt
@@ -2187,8 +2187,9 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
 
   @Test fun `when a generic parameter can't be resolved the exception contains its location`() {
     // This issue can only happen with KSP mode and no component processing mode, ignore others
-    if (componentProcessingMode == ComponentProcessingMode.NONE
-      && mode is AnvilCompilationMode.Ksp) {
+    if (componentProcessingMode == ComponentProcessingMode.NONE &&
+      mode is AnvilCompilationMode.Ksp
+    ) {
       compile(
         """
         package com.squareup.test
@@ -2212,7 +2213,11 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
       ) {
         val lines = messages.split("\n")
         val exceptionLine =
-          lines.find { it.contains("Error type '<ERROR TYPE>' is not resolvable in the current round of processing") }
+          lines.find {
+            it.contains(
+              "Error type '<ERROR TYPE>' is not resolvable in the current round of processing",
+            )
+          }
         assertThat(exceptionLine).isNotNull()
         assertThat(exceptionLine).contains("strings : List<[Error type: Unresolved type for Foo]>")
         assertThat(exceptionLine).contains(".kt:10")


### PR DESCRIPTION
When having a code like:

```kotlin
class SomeClass @AssistedInject constructor(
    private val presenter: Presenter<Foo>,
) { ... }
```

If `Foo` hasn't been properly imported (i.e. in the middle of a refactor), KotlinPoet code generation will fail with a not really helpful error like:

```
[ksp] java.lang.IllegalArgumentException: Error type '<ERROR TYPE>' is not resolvable in the current round of processing.
	at com.squareup.kotlinpoet.ksp.KsTypesKt.requireNotErrorType(KsTypes.kt:40)
	at com.squareup.kotlinpoet.ksp.KsTypesKt.toTypeName(KsTypes.kt:71)
	at com.squareup.kotlinpoet.ksp.KsTypesKt.toTypeName(KsTypes.kt:199)
	at com.squareup.kotlinpoet.ksp.KsTypesKt.toTypeName(KsTypes.kt:175)
	at com.squareup.kotlinpoet.ksp.KsTypesKt.toTypeName(KsTypes.kt:74)
	at com.squareup.kotlinpoet.ksp.KsTypesKt.toTypeName(KsTypes.kt:65)
	at com.squareup.anvil.compiler.codegen.ksp.KspUtilKt.contextualToTypeName(KspUtil.kt:368)
	at com.squareup.anvil.compiler.codegen.dagger.DaggerGenerationUtilsKt.toConstructorParameter(DaggerGenerationUtils.kt:141)
	at com.squareup.anvil.compiler.codegen.dagger.DaggerGenerationUtilsKt.mapToConstructorParametersKsp(DaggerGenerationUtils.kt:125)
	at com.squareup.anvil.compiler.codegen.dagger.AssistedInjectCodeGen$KspGenerator.generateFactoryClass(AssistedInjectCodeGen.kt:91)
...
```

In the latest version, this has improved and it now displays at least:

```
[ksp] java.lang.IllegalArgumentException: Error type '<ERROR TYPE: Foo>' is not resolvable in the current round of processing.
```

But it still won't tell you where the code generation is failing, so you'd have to check every single usage of this class to try to understand where the error is.

I added some code that, when trying to get the underlying type for KotlinPoet fails, will wrap the original exception adding some context about the name and location of the parameter that caused the code generation issue, like this:

```
e: [ksp] java.lang.IllegalArgumentException: Failed to resolve type for parameter 'typingNotificationPresenter' at /some/long/path/TimelinePresenter.kt:74
        at com.squareup.anvil.compiler.codegen.dagger.DaggerGenerationUtilsKt.loggingLocationOnError(DaggerGenerationUtils.kt:627)
        at com.squareup.anvil.compiler.codegen.dagger.DaggerGenerationUtilsKt.toConstructorParameter(DaggerGenerationUtils.kt:145)
        at com.squareup.anvil.compiler.codegen.dagger.DaggerGenerationUtilsKt.mapToConstructorParametersKsp(DaggerGenerationUtils.kt:129)
        at com.squareup.anvil.compiler.codegen.dagger.AssistedInjectCodeGen$KspGenerator.generateFactoryClass(AssistedInjectCodeGen.kt:91)
        at com.squareup.anvil.compiler.codegen.dagger.AssistedInjectCodeGen$KspGenerator.processChecked(AssistedInjectCodeGen.kt:75)
        at com.squareup.anvil.compiler.codegen.ksp.AnvilSymbolProcessor.runInternal(AnvilSymbolProcessing.kt:60)
        at com.squareup.anvil.compiler.codegen.ksp.AnvilSymbolProcessor.process(AnvilSymbolProcessing.kt:50)
        at com.google.devtools.ksp.AbstractKotlinSymbolProcessingExtension$doAnalysis$8$1.invoke(KotlinSymbolProcessingExtension.kt:310)
        at com.google.devtools.ksp.AbstractKotlinSymbolProcessingExtension$doAnalysis$8$1.invoke(KotlinSymbolProcessingExtension.kt:308)
        at com.google.devtools.ksp.AbstractKotlinSymbolProcessingExtension.handleException(KotlinSymbolProcessingExtension.kt:414)
        at com.google.devtools.ksp.AbstractKotlinSymbolProcessingExtension.doAnalysis(KotlinSymbolProcessingExtension.kt:308)
        at org.jetbrains.kotlin.cli.jvm.compiler.TopDownAnalyzerFacadeForJVM.analyzeFilesWithJavaIntegration(TopDownAnalyzerFacadeForJVM.kt:112)
        at org.jetbrains.kotlin.cli.jvm.compiler.TopDownAnalyzerFacadeForJVM.analyzeFilesWithJavaIntegration$default(TopDownAnalyzerFacadeForJVM.kt:75)
        at org.jetbrains.kotlin.cli.jvm.compiler.KotlinToJVMBytecodeCompiler.analyze$lambda$12(KotlinToJVMBytecodeCompiler.kt:373)
        at org.jetbrains.kotlin.cli.common.messages.AnalyzerWithCompilerReport.analyzeAndReport(AnalyzerWithCompilerReport.kt:112)
        at org.jetbrains.kotlin.cli.jvm.compiler.KotlinToJVMBytecodeCompiler.analyze(KotlinToJVMBytecodeCompiler.kt:364)
        at org.jetbrains.kotlin.cli.jvm.compiler.KotlinToJVMBytecodeCompiler.runFrontendAndGenerateIrUsingClassicFrontend(KotlinToJVMBytecodeCompiler.kt:195)
        at org.jetbrains.kotlin.cli.jvm.compiler.KotlinToJVMBytecodeCompiler.compileModules$cli(KotlinToJVMBytecodeCompiler.kt:106)
        at org.jetbrains.kotlin.cli.jvm.K2JVMCompiler.doExecute(K2JVMCompiler.kt:170)
        at org.jetbrains.kotlin.cli.jvm.K2JVMCompiler.doExecute(K2JVMCompiler.kt:43)
        at org.jetbrains.kotlin.cli.common.CLICompiler.execImpl(CLICompiler.kt:103)
        at org.jetbrains.kotlin.cli.common.CLICompiler.execImpl(CLICompiler.kt:49)
        at org.jetbrains.kotlin.cli.common.CLITool.exec(CLITool.kt:101)
        at org.jetbrains.kotlin.daemon.CompileServiceImpl.compile(CompileServiceImpl.kt:1555)
        at jdk.internal.reflect.GeneratedMethodAccessor12.invoke(Unknown Source)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:568)
        at java.rmi/sun.rmi.server.UnicastServerRef.dispatch(UnicastServerRef.java:360)
        at java.rmi/sun.rmi.transport.Transport$1.run(Transport.java:200)
        at java.rmi/sun.rmi.transport.Transport$1.run(Transport.java:197)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:712)
        at java.rmi/sun.rmi.transport.Transport.serviceCall(Transport.java:196)
        at java.rmi/sun.rmi.transport.tcp.TCPTransport.handleMessages(TCPTransport.java:587)
        at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run0(TCPTransport.java:828)
        at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.lambda$run$0(TCPTransport.java:705)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
        at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run(TCPTransport.java:704)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:840)
Caused by: java.lang.IllegalArgumentException: Error type '<ERROR TYPE: TypingNotificationState>' is not resolvable in the current round of processing.
        at com.squareup.kotlinpoet.ksp.KsTypesKt.requireNotErrorType(KsTypes.kt:40)
        at com.squareup.kotlinpoet.ksp.KsTypesKt.toTypeName(KsTypes.kt:71)
        at com.squareup.kotlinpoet.ksp.KsTypesKt.toTypeName(KsTypes.kt:202)
        at com.squareup.kotlinpoet.ksp.KsTypesKt.toTypeName(KsTypes.kt:177)
        at com.squareup.kotlinpoet.ksp.KsTypesKt.toTypeName(KsTypes.kt:74)
        at com.squareup.kotlinpoet.ksp.KsTypesKt.toTypeName(KsTypes.kt:65)
        at com.squareup.anvil.compiler.codegen.ksp.KspUtilKt.contextualToTypeName(KspUtil.kt:368)
        at com.squareup.anvil.compiler.codegen.dagger.DaggerGenerationUtilsKt$toConstructorParameter$paramTypeName$1.invoke(DaggerGenerationUtils.kt:145)
        at com.squareup.anvil.compiler.codegen.dagger.DaggerGenerationUtilsKt$toConstructorParameter$paramTypeName$1.invoke(DaggerGenerationUtils.kt:145)
        at com.squareup.anvil.compiler.codegen.dagger.DaggerGenerationUtilsKt.loggingLocationOnError(DaggerGenerationUtils.kt:621)
        ... 39 more

e: Error occurred in KSP, check log for detail
```

I'm not really sure about how this was handled, so feel free to suggest or replace the implementation for something better, or add it in other places where this issue may happen: I only know of this one, but there could be more.