### PR TITLE
make annotations-optional a KMP library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 - **Enhancement**: Improve error messaging for error types used as annotation arguments.
 - **Enhancement**: Initial support for jakarta.inject annotations. Note that Dagger itself appears to only partially support these at the moment. Generated code is identical, but jakarta `@Inject`/`@Qualifier`/`@Scope` annotations should be recognized now.
+- **Enhancement**: `annotations` and `annotations-optional` are now Kotlin multiplatfom libraries.
+- **Enhancement**: `@SingleIn` and `@ForScope` can now be used with jakarta.inject and kotlin-inject.
 - Update Dagger to `2.52`.
 
 0.3.3

--- a/annotations-optional/build.gradle.kts
+++ b/annotations-optional/build.gradle.kts
@@ -10,6 +10,7 @@ publish {
     artifactId = "annotations-optional",
     pomName = "Anvil Optional Annotations",
     pomDescription = "Optional annotations that we\"ve found to be helpful with managing larger dependency graphs",
+    overrideArtifactId = false,
   )
 }
 

--- a/annotations-optional/build.gradle.kts
+++ b/annotations-optional/build.gradle.kts
@@ -22,4 +22,5 @@ kotlin {
 
 dependencies {
   jvmMainApi(libs.inject)
+  jvmMainApi(libs.jakarta)
 }

--- a/annotations-optional/build.gradle.kts
+++ b/annotations-optional/build.gradle.kts
@@ -21,6 +21,10 @@ kotlin {
 }
 
 dependencies {
-  jvmMainApi(libs.inject)
-  jvmMainApi(libs.jakarta)
+  commonMainCompileOnly(libs.kotlinInject)
+  // non jvm targets don't support compile only dependencies
+  nonJvmMainApi(libs.kotlinInject)
+
+  jvmMainCompileOnly(libs.inject)
+  jvmMainCompileOnly(libs.jakarta)
 }

--- a/annotations-optional/build.gradle.kts
+++ b/annotations-optional/build.gradle.kts
@@ -1,5 +1,7 @@
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+
 plugins {
-  id("conventions.library")
+  id("conventions.kmp-library")
   id("conventions.publish")
 }
 
@@ -11,6 +13,13 @@ publish {
   )
 }
 
+kotlin {
+  @OptIn(ExperimentalKotlinGradlePluginApi::class)
+  compilerOptions {
+    freeCompilerArgs.add("-Xexpect-actual-classes")
+  }
+}
+
 dependencies {
-  api(libs.inject)
+  jvmMainApi(libs.inject)
 }

--- a/annotations-optional/src/commonMain/kotlin/com/squareup/anvil/annotations/optional/ForScope.kt
+++ b/annotations-optional/src/commonMain/kotlin/com/squareup/anvil/annotations/optional/ForScope.kt
@@ -1,0 +1,33 @@
+package com.squareup.anvil.annotations.optional
+
+import kotlin.annotation.AnnotationRetention.RUNTIME
+import kotlin.reflect.KClass
+
+/**
+ * A class based [qualfier](Qualifier).
+ *
+ * This can be used in combination with other Anvil annotations to avoid having
+ * to manually define qualifier annotations for each component and to maintain
+ * consistency.
+ *
+ * Example:
+ * ```
+ * interface Authenticator
+ *
+ * @ForScope(AppScope::class)
+ * @ContributesBinding(AppScope::class)
+ * class CommonAuthenticator @Inject constructor() : Authenticator
+ *
+ * @ForScope(UserScope::class)
+ * @ContributesBinding(UserScope::class)
+ * class UserAuthenticator @Inject constructor() : Authenticator
+ * ```
+ */
+@Retention(RUNTIME)
+public expect annotation class ForScope(
+  /**
+   * The marker that identifies the component in which the annotated object is
+   * provided or bound in.
+   */
+  val scope: KClass<*>,
+)

--- a/annotations-optional/src/commonMain/kotlin/com/squareup/anvil/annotations/optional/ForScope.kt
+++ b/annotations-optional/src/commonMain/kotlin/com/squareup/anvil/annotations/optional/ForScope.kt
@@ -5,7 +5,7 @@ import kotlin.reflect.KClass
 import me.tatarka.inject.annotations.Scope as KotlinInjectScope
 
 /**
- * A class based [qualfier](Qualifier).
+ * A class based [qualifier](Qualifier).
  *
  * This can be used in combination with other Anvil annotations to avoid having
  * to manually define qualifier annotations for each component and to maintain

--- a/annotations-optional/src/commonMain/kotlin/com/squareup/anvil/annotations/optional/ForScope.kt
+++ b/annotations-optional/src/commonMain/kotlin/com/squareup/anvil/annotations/optional/ForScope.kt
@@ -2,6 +2,7 @@ package com.squareup.anvil.annotations.optional
 
 import kotlin.annotation.AnnotationRetention.RUNTIME
 import kotlin.reflect.KClass
+import me.tatarka.inject.annotations.Scope as KotlinInjectScope
 
 /**
  * A class based [qualfier](Qualifier).
@@ -23,6 +24,7 @@ import kotlin.reflect.KClass
  * class UserAuthenticator @Inject constructor() : Authenticator
  * ```
  */
+@KotlinInjectScope
 @Retention(RUNTIME)
 public expect annotation class ForScope(
   /**

--- a/annotations-optional/src/commonMain/kotlin/com/squareup/anvil/annotations/optional/SingleIn.kt
+++ b/annotations-optional/src/commonMain/kotlin/com/squareup/anvil/annotations/optional/SingleIn.kt
@@ -2,6 +2,7 @@ package com.squareup.anvil.annotations.optional
 
 import kotlin.annotation.AnnotationRetention.RUNTIME
 import kotlin.reflect.KClass
+import me.tatarka.inject.annotations.Qualifier as KotlinInjectQualifier
 
 /**
  * Identifies a type that the injector only instantiates once for the given
@@ -29,6 +30,7 @@ import kotlin.reflect.KClass
  *
  * See Also: [@Scope](Scope)
  */
+@KotlinInjectQualifier
 @Retention(RUNTIME)
 public expect annotation class SingleIn(
   /**

--- a/annotations-optional/src/commonMain/kotlin/com/squareup/anvil/annotations/optional/SingleIn.kt
+++ b/annotations-optional/src/commonMain/kotlin/com/squareup/anvil/annotations/optional/SingleIn.kt
@@ -1,6 +1,5 @@
 package com.squareup.anvil.annotations.optional
 
-import javax.inject.Scope
 import kotlin.annotation.AnnotationRetention.RUNTIME
 import kotlin.reflect.KClass
 
@@ -30,9 +29,8 @@ import kotlin.reflect.KClass
  *
  * See Also: [@Scope](Scope)
  */
-@Scope
 @Retention(RUNTIME)
-public annotation class SingleIn(
+public expect annotation class SingleIn(
   /**
    * The marker that identifies this scope.
    */

--- a/annotations-optional/src/jvmMain/kotlin/com/squareup/anvil/annotations/optional/ForScope.kt
+++ b/annotations-optional/src/jvmMain/kotlin/com/squareup/anvil/annotations/optional/ForScope.kt
@@ -4,6 +4,7 @@ import kotlin.annotation.AnnotationRetention.RUNTIME
 import kotlin.reflect.KClass
 import jakarta.inject.Qualifier as JakartaQualifier
 import javax.inject.Qualifier as JavaxQualifier
+import me.tatarka.inject.annotations.Qualifier as KotlinInjectQualifier
 
 /**
  * A class based [qualfier](Qualifier).
@@ -27,6 +28,7 @@ import javax.inject.Qualifier as JavaxQualifier
  */
 @JavaxQualifier
 @JakartaQualifier
+@KotlinInjectQualifier
 @Retention(RUNTIME)
 public actual annotation class ForScope(
   /**

--- a/annotations-optional/src/jvmMain/kotlin/com/squareup/anvil/annotations/optional/ForScope.kt
+++ b/annotations-optional/src/jvmMain/kotlin/com/squareup/anvil/annotations/optional/ForScope.kt
@@ -1,8 +1,9 @@
 package com.squareup.anvil.annotations.optional
 
-import javax.inject.Qualifier
 import kotlin.annotation.AnnotationRetention.RUNTIME
 import kotlin.reflect.KClass
+import jakarta.inject.Qualifier as JakartaQualifier
+import javax.inject.Qualifier as JavaxQualifier
 
 /**
  * A class based [qualfier](Qualifier).
@@ -24,7 +25,8 @@ import kotlin.reflect.KClass
  * class UserAuthenticator @Inject constructor() : Authenticator
  * ```
  */
-@Qualifier
+@JavaxQualifier
+@JakartaQualifier
 @Retention(RUNTIME)
 public actual annotation class ForScope(
   /**

--- a/annotations-optional/src/jvmMain/kotlin/com/squareup/anvil/annotations/optional/ForScope.kt
+++ b/annotations-optional/src/jvmMain/kotlin/com/squareup/anvil/annotations/optional/ForScope.kt
@@ -1,0 +1,35 @@
+package com.squareup.anvil.annotations.optional
+
+import javax.inject.Qualifier
+import kotlin.annotation.AnnotationRetention.RUNTIME
+import kotlin.reflect.KClass
+
+/**
+ * A class based [qualfier](Qualifier).
+ *
+ * This can be used in combination with other Anvil annotations to avoid having
+ * to manually define qualifier annotations for each component and to maintain
+ * consistency.
+ *
+ * Example:
+ * ```
+ * interface Authenticator
+ *
+ * @ForScope(AppScope::class)
+ * @ContributesBinding(AppScope::class)
+ * class CommonAuthenticator @Inject constructor() : Authenticator
+ *
+ * @ForScope(UserScope::class)
+ * @ContributesBinding(UserScope::class)
+ * class UserAuthenticator @Inject constructor() : Authenticator
+ * ```
+ */
+@Qualifier
+@Retention(RUNTIME)
+public actual annotation class ForScope(
+  /**
+   * The marker that identifies the component in which the annotated object is
+   * provided or bound in.
+   */
+  actual val scope: KClass<*>,
+)

--- a/annotations-optional/src/jvmMain/kotlin/com/squareup/anvil/annotations/optional/ForScope.kt
+++ b/annotations-optional/src/jvmMain/kotlin/com/squareup/anvil/annotations/optional/ForScope.kt
@@ -7,7 +7,7 @@ import javax.inject.Qualifier as JavaxQualifier
 import me.tatarka.inject.annotations.Qualifier as KotlinInjectQualifier
 
 /**
- * A class based [qualfier](Qualifier).
+ * A class based [qualifier](Qualifier).
  *
  * This can be used in combination with other Anvil annotations to avoid having
  * to manually define qualifier annotations for each component and to maintain

--- a/annotations-optional/src/jvmMain/kotlin/com/squareup/anvil/annotations/optional/SingleIn.kt
+++ b/annotations-optional/src/jvmMain/kotlin/com/squareup/anvil/annotations/optional/SingleIn.kt
@@ -1,0 +1,40 @@
+package com.squareup.anvil.annotations.optional
+
+import javax.inject.Scope
+import kotlin.annotation.AnnotationRetention.RUNTIME
+import kotlin.reflect.KClass
+
+/**
+ * Identifies a type that the injector only instantiates once for the given
+ * [scope] marker.
+ *
+ * This can be used in combination with other Anvil annotations to avoid having
+ * to manually define scope annotations for each component and to maintain
+ * consistency.
+ *
+ * Component example:
+ * ```
+ * @SingleIn(AppScope::class)
+ * @MergeComponent(AppScope::class)
+ * interface AppComponent
+ * ```
+ *
+ * Contribution example:
+ * ```
+ * interface Authenticator
+ *
+ * @SingleIn(AppScope::class)
+ * @ContributesBinding(AppScope::class)
+ * class RealAuthenticator @Inject constructor() : Authenticator
+ * ```
+ *
+ * See Also: [@Scope](Scope)
+ */
+@Scope
+@Retention(RUNTIME)
+public actual annotation class SingleIn(
+  /**
+   * The marker that identifies this scope.
+   */
+  actual val scope: KClass<*>,
+)

--- a/annotations-optional/src/jvmMain/kotlin/com/squareup/anvil/annotations/optional/SingleIn.kt
+++ b/annotations-optional/src/jvmMain/kotlin/com/squareup/anvil/annotations/optional/SingleIn.kt
@@ -1,8 +1,9 @@
 package com.squareup.anvil.annotations.optional
 
-import javax.inject.Scope
 import kotlin.annotation.AnnotationRetention.RUNTIME
 import kotlin.reflect.KClass
+import jakarta.inject.Scope as JakartaScope
+import javax.inject.Scope as JavaxScope
 
 /**
  * Identifies a type that the injector only instantiates once for the given
@@ -30,7 +31,8 @@ import kotlin.reflect.KClass
  *
  * See Also: [@Scope](Scope)
  */
-@Scope
+@JavaxScope
+@JakartaScope
 @Retention(RUNTIME)
 public actual annotation class SingleIn(
   /**

--- a/annotations-optional/src/jvmMain/kotlin/com/squareup/anvil/annotations/optional/SingleIn.kt
+++ b/annotations-optional/src/jvmMain/kotlin/com/squareup/anvil/annotations/optional/SingleIn.kt
@@ -4,6 +4,7 @@ import kotlin.annotation.AnnotationRetention.RUNTIME
 import kotlin.reflect.KClass
 import jakarta.inject.Scope as JakartaScope
 import javax.inject.Scope as JavaxScope
+import me.tatarka.inject.annotations.Scope as KotlinInjectScope
 
 /**
  * Identifies a type that the injector only instantiates once for the given
@@ -33,6 +34,7 @@ import javax.inject.Scope as JavaxScope
  */
 @JavaxScope
 @JakartaScope
+@KotlinInjectScope
 @Retention(RUNTIME)
 public actual annotation class SingleIn(
   /**

--- a/annotations-optional/src/nonJvmMain/kotlin/com/squareup/anvil/annotations/optional/ForScope.kt
+++ b/annotations-optional/src/nonJvmMain/kotlin/com/squareup/anvil/annotations/optional/ForScope.kt
@@ -2,6 +2,7 @@ package com.squareup.anvil.annotations.optional
 
 import kotlin.annotation.AnnotationRetention.RUNTIME
 import kotlin.reflect.KClass
+import me.tatarka.inject.annotations.Qualifier as KotlinInjectQualifier
 
 /**
  * A class based [qualfier](Qualifier).
@@ -23,6 +24,7 @@ import kotlin.reflect.KClass
  * class UserAuthenticator @Inject constructor() : Authenticator
  * ```
  */
+@KotlinInjectQualifier
 @Retention(RUNTIME)
 public actual annotation class ForScope(
   /**

--- a/annotations-optional/src/nonJvmMain/kotlin/com/squareup/anvil/annotations/optional/ForScope.kt
+++ b/annotations-optional/src/nonJvmMain/kotlin/com/squareup/anvil/annotations/optional/ForScope.kt
@@ -1,6 +1,5 @@
 package com.squareup.anvil.annotations.optional
 
-import javax.inject.Qualifier
 import kotlin.annotation.AnnotationRetention.RUNTIME
 import kotlin.reflect.KClass
 
@@ -24,12 +23,11 @@ import kotlin.reflect.KClass
  * class UserAuthenticator @Inject constructor() : Authenticator
  * ```
  */
-@Qualifier
 @Retention(RUNTIME)
-public annotation class ForScope(
+public actual annotation class ForScope(
   /**
    * The marker that identifies the component in which the annotated object is
    * provided or bound in.
    */
-  val scope: KClass<*>,
+  actual val scope: KClass<*>,
 )

--- a/annotations-optional/src/nonJvmMain/kotlin/com/squareup/anvil/annotations/optional/ForScope.kt
+++ b/annotations-optional/src/nonJvmMain/kotlin/com/squareup/anvil/annotations/optional/ForScope.kt
@@ -5,7 +5,7 @@ import kotlin.reflect.KClass
 import me.tatarka.inject.annotations.Qualifier as KotlinInjectQualifier
 
 /**
- * A class based [qualfier](Qualifier).
+ * A class based [qualifier](Qualifier).
  *
  * This can be used in combination with other Anvil annotations to avoid having
  * to manually define qualifier annotations for each component and to maintain

--- a/annotations-optional/src/nonJvmMain/kotlin/com/squareup/anvil/annotations/optional/SingleIn.kt
+++ b/annotations-optional/src/nonJvmMain/kotlin/com/squareup/anvil/annotations/optional/SingleIn.kt
@@ -2,6 +2,7 @@ package com.squareup.anvil.annotations.optional
 
 import kotlin.annotation.AnnotationRetention.RUNTIME
 import kotlin.reflect.KClass
+import me.tatarka.inject.annotations.Scope as KotlinInjectScope
 
 /**
  * Identifies a type that the injector only instantiates once for the given
@@ -29,6 +30,7 @@ import kotlin.reflect.KClass
  *
  * See Also: [@Scope](Scope)
  */
+@KotlinInjectScope
 @Retention(RUNTIME)
 public actual annotation class SingleIn(
   /**

--- a/annotations-optional/src/nonJvmMain/kotlin/com/squareup/anvil/annotations/optional/SingleIn.kt
+++ b/annotations-optional/src/nonJvmMain/kotlin/com/squareup/anvil/annotations/optional/SingleIn.kt
@@ -1,0 +1,38 @@
+package com.squareup.anvil.annotations.optional
+
+import kotlin.annotation.AnnotationRetention.RUNTIME
+import kotlin.reflect.KClass
+
+/**
+ * Identifies a type that the injector only instantiates once for the given
+ * [scope] marker.
+ *
+ * This can be used in combination with other Anvil annotations to avoid having
+ * to manually define scope annotations for each component and to maintain
+ * consistency.
+ *
+ * Component example:
+ * ```
+ * @SingleIn(AppScope::class)
+ * @MergeComponent(AppScope::class)
+ * interface AppComponent
+ * ```
+ *
+ * Contribution example:
+ * ```
+ * interface Authenticator
+ *
+ * @SingleIn(AppScope::class)
+ * @ContributesBinding(AppScope::class)
+ * class RealAuthenticator @Inject constructor() : Authenticator
+ * ```
+ *
+ * See Also: [@Scope](Scope)
+ */
+@Retention(RUNTIME)
+public actual annotation class SingleIn(
+  /**
+   * The marker that identifies this scope.
+   */
+  actual val scope: KClass<*>,
+)

--- a/build-logic/conventions/src/main/kotlin/com/squareup/anvil/conventions/LibraryKmpPlugin.kt
+++ b/build-logic/conventions/src/main/kotlin/com/squareup/anvil/conventions/LibraryKmpPlugin.kt
@@ -54,6 +54,15 @@ class LibraryKmpPlugin : Plugin<Project> {
       mingwX64()
 
       applyDefaultHierarchyTemplate()
+
+      sourceSets.apply {
+        val nonJvmMain = create("nonJvmMain")
+        nonJvmMain.dependsOn(commonMain.get())
+
+        nativeMain.get().dependsOn(nonJvmMain)
+        jsMain.get().dependsOn(nonJvmMain)
+        getByName("wasmJsMain").dependsOn(nonJvmMain)
+      }
     }
     configureBinaryCompatibilityValidator()
     configureExplicitApi()

--- a/build-logic/conventions/src/main/kotlin/com/squareup/anvil/conventions/LibraryKmpPlugin.kt
+++ b/build-logic/conventions/src/main/kotlin/com/squareup/anvil/conventions/LibraryKmpPlugin.kt
@@ -51,7 +51,8 @@ class LibraryKmpPlugin : Plugin<Project> {
       watchosSimulatorArm64()
       watchosX64()
 
-      mingwX64()
+      // TODO: re-enable when kotlin-inject supports it
+      // mingwX64()
 
       applyDefaultHierarchyTemplate()
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -49,3 +49,6 @@ android.defaults.buildfeatures.viewBinding=false
 
 # Suppress the warning about MPP being in alpha.
 kotlin.mpp.stability.nowarn=true
+
+# TODO: remove when updating to Kotlin 2.0
+kotlin.native.ignoreIncorrectDependencies=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -101,6 +101,7 @@ gradlePublishRaw = { module = "com.gradle.publish:plugin-publish-plugin", versio
 guava = "com.google.guava:guava:33.2.1-jre"
 
 inject = "javax.inject:javax.inject:1"
+kotlinInject = "me.tatarka.inject:kotlin-inject-runtime:0.7.2"
 jakarta = "jakarta.inject:jakarta.inject-api:2.0.1"
 jsr250 = "javax.annotation:jsr250-api:1.0"
 junit = "junit:junit:4.13.2"


### PR DESCRIPTION
With this `ForScope` and `SingleIn` can be used with both Dagger and kotlin-inject. All targets have the kotlin-inject annotations and the jvm target has the javax.inject annotations like before (I've also added jakarta while I was at it).