### PR TITLE
simplify publishing config

### DIFF
--- a/annotations-optional/build.gradle.kts
+++ b/annotations-optional/build.gradle.kts
@@ -10,7 +10,6 @@ publish {
     artifactId = "annotations-optional",
     pomName = "Anvil Optional Annotations",
     pomDescription = "Optional annotations that we\"ve found to be helpful with managing larger dependency graphs",
-    overrideArtifactId = false,
   )
 }
 

--- a/annotations/build.gradle.kts
+++ b/annotations/build.gradle.kts
@@ -8,6 +8,5 @@ publish {
     artifactId = "annotations",
     pomName = "Anvil Annotations",
     pomDescription = "Annotations used to mark classes and methods for code generation in Anvil",
-    overrideArtifactId = false,
   )
 }

--- a/build-logic/conventions/src/main/kotlin/com/squareup/anvil/conventions/PublishConventionPlugin.kt
+++ b/build-logic/conventions/src/main/kotlin/com/squareup/anvil/conventions/PublishConventionPlugin.kt
@@ -13,7 +13,6 @@ import com.vanniktech.maven.publish.KotlinMultiplatform
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.publish.tasks.GenerateModuleMetadata
 import org.gradle.api.tasks.bundling.Jar
 import org.jetbrains.dokka.gradle.AbstractDokkaTask

--- a/build-logic/conventions/src/main/kotlin/com/squareup/anvil/conventions/PublishConventionPlugin.kt
+++ b/build-logic/conventions/src/main/kotlin/com/squareup/anvil/conventions/PublishConventionPlugin.kt
@@ -22,8 +22,6 @@ import javax.inject.Inject
 
 open class PublishConventionPlugin : Plugin<Project> {
   override fun apply(target: Project) {
-    target.extensions.create("publish", PublishExtension::class.java)
-
     target.plugins.apply("com.vanniktech.maven.publish.base")
     target.plugins.apply("org.jetbrains.dokka")
 
@@ -32,6 +30,8 @@ open class PublishConventionPlugin : Plugin<Project> {
 
     val mavenPublishing = target.extensions
       .getByType(MavenPublishBaseExtension::class.java)
+
+    target.extensions.create("publish", PublishExtension::class.java, mavenPublishing)
 
     val pluginPublishId = target.libs.plugins.gradlePublish.pluginId
 
@@ -132,30 +132,18 @@ open class PublishConventionPlugin : Plugin<Project> {
 }
 
 open class PublishExtension @Inject constructor(
-  private val target: Project,
+  private val extension: MavenPublishBaseExtension,
 ) {
 
   fun configurePom(
     artifactId: String,
     pomName: String,
     pomDescription: String,
-    overrideArtifactId: Boolean = true,
   ) {
-
-    target.gradlePublishingExtension
-      .publications.withType(MavenPublication::class.java)
-      .configureEach { publication ->
-
-        // Gradle plugin publications have their own artifactID convention,
-        // and that's handled automatically.
-        if (!publication.name.endsWith("PluginMarkerMaven") && overrideArtifactId) {
-          publication.artifactId = artifactId
-        }
-
-        publication.pom {
-          it.name.set(pomName)
-          it.description.set(pomDescription)
-        }
-      }
+    extension.coordinates(artifactId = artifactId)
+    extension.pom {
+      it.name.set(pomName)
+      it.description.set(pomDescription)
+    }
   }
 }


### PR DESCRIPTION
Makes `configurePom` use the maven publish plugin extension internally instead of directly interacting with publications. That way the `PluginMarkerMaven` publication doesn't need to be handled manually and `overrideArtifactId` isn't needed because it properly deals with KMP projects.