### PR TITLE
ContributeSubComponent: Support returning Super Type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 **Unreleased**
 --------------
 
+### Deprecated
+- `ClassReference.functions` has been deprecated in favor of `ClassReference.memberFunctions` and `ClassReference.declaredMemberFunctions`
+- `ClassReference.properties` has been deprecated in favor of `ClassReference.memberProperties` and `ClassReference.declaredMemberProperties`
+
 0.4.0
 -----
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 
 ### Deprecated
 - `ClassReference.functions` has been deprecated in favor of `ClassReference.memberFunctions` and `ClassReference.declaredMemberFunctions`
-- `ClassReference.properties` has been deprecated in favor of `ClassReference.memberProperties` and `ClassReference.declaredMemberProperties`
 
 0.4.0
 -----

--- a/compiler-utils/api/compiler-utils.api
+++ b/compiler-utils/api/compiler-utils.api
@@ -301,12 +301,10 @@ public abstract class com/squareup/anvil/compiler/internal/reference/ClassRefere
 	public abstract fun getConstructors ()Ljava/util/List;
 	public abstract fun getContainingFileAsJavaFile ()Ljava/io/File;
 	public abstract fun getDeclaredMemberFunctions ()Ljava/util/List;
-	public abstract fun getDeclaredMemberProperties ()Ljava/util/List;
 	public abstract fun getFqName ()Lorg/jetbrains/kotlin/name/FqName;
 	public abstract fun getFunctions ()Ljava/util/List;
 	protected abstract fun getInnerClassesAndObjects ()Ljava/util/List;
 	public final fun getMemberFunctions ()Ljava/util/List;
-	public final fun getMemberProperties ()Ljava/util/List;
 	public abstract fun getModule ()Lcom/squareup/anvil/compiler/internal/reference/AnvilModuleDescriptor;
 	public final fun getPackageFqName ()Lorg/jetbrains/kotlin/name/FqName;
 	public abstract fun getProperties ()Ljava/util/List;
@@ -335,7 +333,6 @@ public final class com/squareup/anvil/compiler/internal/reference/ClassReference
 	public fun getConstructors ()Ljava/util/List;
 	public fun getContainingFileAsJavaFile ()Ljava/io/File;
 	public fun getDeclaredMemberFunctions ()Ljava/util/List;
-	public fun getDeclaredMemberProperties ()Ljava/util/List;
 	public fun getFqName ()Lorg/jetbrains/kotlin/name/FqName;
 	public fun getFunctions ()Ljava/util/List;
 	public fun getModule ()Lcom/squareup/anvil/compiler/internal/reference/AnvilModuleDescriptor;
@@ -362,7 +359,6 @@ public final class com/squareup/anvil/compiler/internal/reference/ClassReference
 	public fun getConstructors ()Ljava/util/List;
 	public fun getContainingFileAsJavaFile ()Ljava/io/File;
 	public fun getDeclaredMemberFunctions ()Ljava/util/List;
-	public fun getDeclaredMemberProperties ()Ljava/util/List;
 	public fun getFqName ()Lorg/jetbrains/kotlin/name/FqName;
 	public fun getFunctions ()Ljava/util/List;
 	public fun getModule ()Lcom/squareup/anvil/compiler/internal/reference/AnvilModuleDescriptor;

--- a/compiler-utils/api/compiler-utils.api
+++ b/compiler-utils/api/compiler-utils.api
@@ -300,9 +300,13 @@ public abstract class com/squareup/anvil/compiler/internal/reference/ClassRefere
 	public abstract fun getClassId ()Lorg/jetbrains/kotlin/name/ClassId;
 	public abstract fun getConstructors ()Ljava/util/List;
 	public abstract fun getContainingFileAsJavaFile ()Ljava/io/File;
+	public abstract fun getDeclaredMemberFunctions ()Ljava/util/List;
+	public abstract fun getDeclaredMemberProperties ()Ljava/util/List;
 	public abstract fun getFqName ()Lorg/jetbrains/kotlin/name/FqName;
 	public abstract fun getFunctions ()Ljava/util/List;
 	protected abstract fun getInnerClassesAndObjects ()Ljava/util/List;
+	public final fun getMemberFunctions ()Ljava/util/List;
+	public final fun getMemberProperties ()Ljava/util/List;
 	public abstract fun getModule ()Lcom/squareup/anvil/compiler/internal/reference/AnvilModuleDescriptor;
 	public final fun getPackageFqName ()Lorg/jetbrains/kotlin/name/FqName;
 	public abstract fun getProperties ()Ljava/util/List;
@@ -330,6 +334,8 @@ public final class com/squareup/anvil/compiler/internal/reference/ClassReference
 	public final fun getClazz ()Lorg/jetbrains/kotlin/descriptors/ClassDescriptor;
 	public fun getConstructors ()Ljava/util/List;
 	public fun getContainingFileAsJavaFile ()Ljava/io/File;
+	public fun getDeclaredMemberFunctions ()Ljava/util/List;
+	public fun getDeclaredMemberProperties ()Ljava/util/List;
 	public fun getFqName ()Lorg/jetbrains/kotlin/name/FqName;
 	public fun getFunctions ()Ljava/util/List;
 	public fun getModule ()Lcom/squareup/anvil/compiler/internal/reference/AnvilModuleDescriptor;
@@ -355,6 +361,8 @@ public final class com/squareup/anvil/compiler/internal/reference/ClassReference
 	public final fun getClazz ()Lorg/jetbrains/kotlin/psi/KtClassOrObject;
 	public fun getConstructors ()Ljava/util/List;
 	public fun getContainingFileAsJavaFile ()Ljava/io/File;
+	public fun getDeclaredMemberFunctions ()Ljava/util/List;
+	public fun getDeclaredMemberProperties ()Ljava/util/List;
 	public fun getFqName ()Lorg/jetbrains/kotlin/name/FqName;
 	public fun getFunctions ()Ljava/util/List;
 	public fun getModule ()Lcom/squareup/anvil/compiler/internal/reference/AnvilModuleDescriptor;

--- a/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/reference/ClassReference.kt
+++ b/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/reference/ClassReference.kt
@@ -88,26 +88,7 @@ public sealed class ClassReference : Comparable<ClassReference>, AnnotatedRefere
       .flatMap { it.asClassReference().memberFunctions }
   }
 
-  @Deprecated(
-    "renamed to `declaredMemberProperties`.  \n" +
-      "Use `memberProperties` to include inherited properties.",
-    replaceWith = ReplaceWith("declaredMemberProperties"),
-  )
   public abstract val properties: List<MemberPropertyReference>
-
-  /**
-   * All properties that are declared in this class, including overrides.
-   * This list does not include inherited properties that are not overridden by this class.
-   */
-  public abstract val declaredMemberProperties: List<MemberPropertyReference>
-
-  /**
-   * All properties declared in this class or any of its super-types.
-   */
-  public val memberProperties: List<MemberPropertyReference> by lazy(NONE) {
-    declaredMemberProperties + directSuperTypeReferences()
-      .flatMap { it.asClassReference().memberProperties }
-  }
 
   public abstract val typeParameters: List<TypeParameterReference>
 
@@ -205,13 +186,7 @@ public sealed class ClassReference : Comparable<ClassReference>, AnnotatedRefere
       clazz.annotationEntries.map { it.toAnnotationReference(this, module) }
     }
 
-    @Deprecated(
-      "renamed to `declaredMemberProperties`.  \nUse `memberProperties` to include inherited properties.",
-      replaceWith = ReplaceWith("declaredMemberProperties"),
-    )
-    override val properties: List<MemberPropertyReference.Psi> get() = declaredMemberProperties
-
-    override val declaredMemberProperties: List<MemberPropertyReference.Psi> by lazy(NONE) {
+    override val properties: List<MemberPropertyReference.Psi> by lazy(NONE) {
       buildList {
         // Order kind of matters here, since the Descriptor APIs will list body/member properties
         // before the constructor properties.
@@ -333,14 +308,7 @@ public sealed class ClassReference : Comparable<ClassReference>, AnnotatedRefere
       clazz.annotations.map { it.toAnnotationReference(this, module) }
     }
 
-    @Deprecated(
-      "renamed to `declaredMemberProperties`.  \nUse `memberProperties` to include inherited properties.",
-      replaceWith = ReplaceWith("declaredMemberProperties"),
-    )
-    override val properties: List<MemberPropertyReference.Descriptor>
-      get() = declaredMemberProperties
-
-    override val declaredMemberProperties: List<MemberPropertyReference.Descriptor> by lazy(NONE) {
+    override val properties: List<MemberPropertyReference.Descriptor> by lazy(NONE) {
       clazz.unsubstitutedMemberScope
         .getDescriptorsFiltered(kindFilter = DescriptorKindFilter.VARIABLES)
         .filterIsInstance<PropertyDescriptor>()

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentCodeGen.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentCodeGen.kt
@@ -207,9 +207,13 @@ internal object ContributesSubcomponentCodeGen : AnvilApplicabilityChecker {
         .filter { it.isAbstract }
         .toList()
 
-      if (functions.size != 1 || functions[0].returnType?.resolve()
-          ?.resolveKSClassDeclaration() != this
-      ) {
+      val returnType = functions.singleOrNull()?.returnType?.resolve()?.resolveKSClassDeclaration()
+      if (returnType != this) {
+
+        val isReturnSuperType = returnType != null && this.superTypes
+          .any { type -> type.resolve().resolveKSClassDeclaration() == returnType }
+        if (isReturnSuperType) return
+
         throw KspAnvilException(
           node = factory,
           message = "A factory must have exactly one abstract function returning the " +
@@ -387,7 +391,13 @@ internal object ContributesSubcomponentCodeGen : AnvilApplicabilityChecker {
           }
         }
 
-      if (functions.size != 1 || functions[0].returnType().asClassReference() != this) {
+      val returnType = functions.singleOrNull()?.returnType()?.asClassReference()
+      if (returnType != this) {
+
+        val isReturnSuperType = returnType != null && this.directSuperTypeReferences()
+          .any { it.asClassReference() == returnType }
+        if (isReturnSuperType) return
+
         throw AnvilCompilationExceptionClassReference(
           classReference = factory,
           message = "A factory must have exactly one abstract function returning the " +

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentCodeGen.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentCodeGen.kt
@@ -325,7 +325,7 @@ internal object ContributesSubcomponentCodeGen : AnvilApplicabilityChecker {
         )
       }
 
-      val functions = componentInterface.functions
+      val functions = componentInterface.memberFunctions
         .filter { it.returnType().asClassReference() == this }
 
       if (functions.size >= 2) {
@@ -378,7 +378,7 @@ internal object ContributesSubcomponentCodeGen : AnvilApplicabilityChecker {
         )
       }
 
-      val functions = factory.functions
+      val functions = factory.memberFunctions
         .let { functions ->
           if (factory.isInterface()) {
             functions

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGenerator.kt
@@ -333,9 +333,16 @@ internal class ContributesSubcomponentHandlerGenerator(
           )
         }
 
+        val superTypes by lazy {
+          contribution.clazz.directSuperTypeReferences()
+            .map { it.asClassReference() }
+        }
         val createComponentFunctions = factory.memberFunctions
           .filter { it.isAbstract() }
-          .filter { it.returnType().asClassReference().fqName == contributionFqName }
+          .filter {
+            val returnType = it.returnType().asClassReference()
+            returnType.fqName == contributionFqName || superTypes.any { s -> s == returnType }
+          }
 
         if (createComponentFunctions.size != 1) {
           throw AnvilCompilationExceptionClassReference(

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGenerator.kt
@@ -333,15 +333,13 @@ internal class ContributesSubcomponentHandlerGenerator(
           )
         }
 
-        val superTypes by lazy {
-          contribution.clazz.directSuperTypeReferences()
-            .map { it.asClassReference() }
-        }
         val createComponentFunctions = factory.memberFunctions
           .filter { it.isAbstract() }
           .filter {
             val returnType = it.returnType().asClassReference()
-            returnType.fqName == contributionFqName || superTypes.any { s -> s == returnType }
+            returnType.fqName == contributionFqName ||
+              contribution.clazz.directSuperTypeReferences()
+                .any { type -> type.asClassReference() == returnType }
           }
 
         if (createComponentFunctions.size != 1) {

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGenerator.kt
@@ -294,7 +294,7 @@ internal class ContributesSubcomponentHandlerGenerator(
       )
     }
 
-    val functions = componentInterface.functions
+    val functions = componentInterface.memberFunctions
       .filter { it.isAbstract() && it.visibility() == PUBLIC }
       .filter {
         val returnType = it.returnType().asClassReference()
@@ -333,7 +333,7 @@ internal class ContributesSubcomponentHandlerGenerator(
           )
         }
 
-        val createComponentFunctions = factory.functions
+        val createComponentFunctions = factory.memberFunctions
           .filter { it.isAbstract() }
           .filter { it.returnType().asClassReference().fqName == contributionFqName }
 

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/KspContributesSubcomponentHandlerSymbolProcessor.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/KspContributesSubcomponentHandlerSymbolProcessor.kt
@@ -406,17 +406,13 @@ internal class KspContributesSubcomponentHandlerSymbolProcessor(
                 function.asMemberOf(implementingType).returnTypeOrNull()
               }
 
-            val returnType = returnTypeToCheck?.resolveKSClassDeclaration()
-            if (returnType?.toClassName() == contributionClassName) {
-              return@filter true
+            if (returnTypeToCheck != null) {
+              val returnTypeClassName = returnTypeToCheck.resolveKSClassDeclaration()?.toClassName()
+              returnTypeClassName == contributionClassName
+                || returnTypeToCheck.isAssignableFrom(contribution.clazz.asType(emptyList()))
+            } else {
+              false
             }
-
-            val isReturningSuperType = returnType != null && contribution.clazz.superTypes.any {
-              it.resolve().resolveKSClassDeclaration() == returnType
-            }
-            if (isReturningSuperType) return@filter true
-
-            false
           }
           .toList()
 

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/KspContributesSubcomponentHandlerSymbolProcessor.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/KspContributesSubcomponentHandlerSymbolProcessor.kt
@@ -405,9 +405,18 @@ internal class KspContributesSubcomponentHandlerSymbolProcessor(
               } else {
                 function.asMemberOf(implementingType).returnTypeOrNull()
               }
-            returnTypeToCheck
-              ?.resolveKSClassDeclaration()
-              ?.toClassName() == contributionClassName
+
+            val returnType = returnTypeToCheck?.resolveKSClassDeclaration()
+            if (returnType?.toClassName() == contributionClassName) {
+              return@filter true
+            }
+
+            val isReturningSuperType = returnType != null && contribution.clazz.superTypes.any {
+              it.resolve().resolveKSClassDeclaration() == returnType
+            }
+            if (isReturningSuperType) return@filter true
+
+            false
           }
           .toList()
 

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/KspContributesSubcomponentHandlerSymbolProcessor.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/KspContributesSubcomponentHandlerSymbolProcessor.kt
@@ -408,8 +408,8 @@ internal class KspContributesSubcomponentHandlerSymbolProcessor(
 
             if (returnTypeToCheck != null) {
               val returnTypeClassName = returnTypeToCheck.resolveKSClassDeclaration()?.toClassName()
-              returnTypeClassName == contributionClassName
-                || returnTypeToCheck.isAssignableFrom(contribution.clazz.asType(emptyList()))
+              returnTypeClassName == contributionClassName ||
+                returnTypeToCheck.isAssignableFrom(contribution.clazz.asType(emptyList()))
             } else {
               false
             }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/AssistedFactoryCodeGen.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/AssistedFactoryCodeGen.kt
@@ -445,7 +445,7 @@ internal object AssistedFactoryCodeGen : AnvilApplicabilityChecker {
       val assistedFunctions = allSuperTypeClassReferences(includeSelf = true)
         .distinctBy { it.fqName }
         .flatMap { clazz ->
-          clazz.functions
+          clazz.declaredMemberFunctions
             .filter {
               it.isAbstract() &&
                 (it.visibility() == Visibility.PUBLIC || it.visibility() == Visibility.PROTECTED)

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/BindsMethodValidator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/BindsMethodValidator.kt
@@ -179,7 +179,7 @@ internal object BindsMethodValidator : AnvilApplicabilityChecker {
         .forEach { clazz ->
           (clazz.companionObjects() + clazz)
             .asSequence()
-            .flatMap { it.functions }
+            .flatMap { it.declaredMemberFunctions }
             .filter { it.isAnnotatedWith(daggerBindsFqName) }
             .also { functions ->
               assertNoDuplicateFunctions(clazz, functions)

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/ProvidesMethodFactoryCodeGen.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/ProvidesMethodFactoryCodeGen.kt
@@ -264,7 +264,7 @@ internal object ProvidesMethodFactoryCodeGen : AnvilApplicabilityChecker {
           .asSequence()
 
         val functions = types
-          .flatMap { it.functions }
+          .flatMap { it.declaredMemberFunctions }
           .filter { it.isAnnotatedWith(daggerProvidesFqName) }
           .onEach { function ->
             checkFunctionIsNotAbstract(clazz, function)

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentGeneratorTest.kt
@@ -110,7 +110,7 @@ class ContributesSubcomponentGeneratorTest(
     }
   }
 
-  @Test fun `there is a hint for contributed subcomponents with an interace factory`() {
+  @Test fun `there is a hint for contributed subcomponents with an interface factory`() {
     compile(
       """
       package com.squareup.test
@@ -518,6 +518,46 @@ class ContributesSubcomponentGeneratorTest(
           interface ComponentFactory : Creator
         }
         
+        @MergeComponent(Unit::class)
+        interface ComponentInterface
+      """,
+      mode = mode,
+    ) {
+      assertThat(subcomponentInterface.hintSubcomponent?.java).isEqualTo(subcomponentInterface)
+      assertThat(subcomponentInterface.hintSubcomponentParentScope).isEqualTo(Unit::class)
+
+      assertThat(subcomponentInterface.componentFactoryInterface.methods.map { it.name })
+        .containsExactly("createComponent")
+    }
+  }
+
+  @Test fun `a factory function may returns the component super type`() {
+    compile(
+      """
+        package com.squareup.test
+
+        import com.squareup.anvil.annotations.ContributesSubcomponent
+        import com.squareup.anvil.annotations.ContributesSubcomponent.Factory
+        import com.squareup.anvil.annotations.ContributesTo
+        import com.squareup.anvil.annotations.MergeComponent
+
+        interface BaseSubcomponentInterface {
+            interface Factory {
+                fun createComponent(): BaseSubcomponentInterface
+            }
+        }
+
+        @ContributesSubcomponent(Any::class, parentScope = Unit::class)
+        interface SubcomponentInterface : BaseSubcomponentInterface {
+          @Factory
+          interface ComponentFactory: BaseSubcomponentInterface.Factory
+
+          @ContributesTo(Unit::class)
+          interface ParentComponent {
+            fun createFactory(): ComponentFactory
+          }
+        }
+
         @MergeComponent(Unit::class)
         interface ComponentInterface
       """,

--- a/compiler/src/test/java/com/squareup/anvil/compiler/internal/reference/ClassReferenceTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/internal/reference/ClassReferenceTest.kt
@@ -201,9 +201,13 @@ class ClassReferenceTest {
               assertThat(psiRef.isGenericClass()).isFalse()
               assertThat(descriptorRef.isGenericClass()).isFalse()
 
-              assertThat(psiRef.functions.single().returnType().isGenericType()).isFalse()
               assertThat(
-                descriptorRef.functions.single { it.name == "string" }
+                psiRef.declaredMemberFunctions.single()
+                  .returnType()
+                  .isGenericType(),
+              ).isFalse()
+              assertThat(
+                descriptorRef.declaredMemberFunctions.single { it.name == "string" }
                   .returnType()
                   .isGenericType(),
               ).isFalse()
@@ -223,17 +227,25 @@ class ClassReferenceTest {
               ).isTrue()
             }
             "SomeClass3" -> {
-              assertThat(psiRef.functions.single().returnType().isGenericType()).isTrue()
               assertThat(
-                descriptorRef.functions.single { it.name == "list" }
+                psiRef.declaredMemberFunctions.single()
+                  .returnType()
+                  .isGenericType(),
+              ).isTrue()
+              assertThat(
+                descriptorRef.declaredMemberFunctions.single { it.name == "list" }
                   .returnType()
                   .isGenericType(),
               ).isTrue()
             }
             "SomeClass4" -> {
-              assertThat(psiRef.functions.single().returnType().isGenericType()).isTrue()
               assertThat(
-                descriptorRef.functions.single { it.name == "list" }
+                psiRef.declaredMemberFunctions.single()
+                  .returnType()
+                  .isGenericType(),
+              ).isTrue()
+              assertThat(
+                descriptorRef.declaredMemberFunctions.single { it.name == "list" }
                   .returnType()
                   .isGenericType(),
               ).isTrue()

--- a/compiler/src/test/java/com/squareup/anvil/compiler/internal/reference/ClassReferenceTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/internal/reference/ClassReferenceTest.kt
@@ -6,15 +6,12 @@ import com.squareup.anvil.compiler.internal.testing.simpleCodeGenerator
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.TypeSpec
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.OK
-import io.kotest.matchers.shouldBe
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.resolve.source.getPsi
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.TestFactory
+import org.junit.Test
 
-@Suppress("LocalVariableName")
-class ClassReferenceTest : ReferenceTests {
+class ClassReferenceTest {
 
   @Test fun `inner classes are parsed`() {
     compile(
@@ -204,11 +201,9 @@ class ClassReferenceTest : ReferenceTests {
               assertThat(psiRef.isGenericClass()).isFalse()
               assertThat(descriptorRef.isGenericClass()).isFalse()
 
+              assertThat(psiRef.functions.single().returnType().isGenericType()).isFalse()
               assertThat(
-                psiRef.declaredMemberFunctions.single().returnType().isGenericType(),
-              ).isFalse()
-              assertThat(
-                descriptorRef.declaredMemberFunctions.single { it.name == "string" }
+                descriptorRef.functions.single { it.name == "string" }
                   .returnType()
                   .isGenericType(),
               ).isFalse()
@@ -228,21 +223,17 @@ class ClassReferenceTest : ReferenceTests {
               ).isTrue()
             }
             "SomeClass3" -> {
+              assertThat(psiRef.functions.single().returnType().isGenericType()).isTrue()
               assertThat(
-                psiRef.declaredMemberFunctions.single().returnType().isGenericType(),
-              ).isTrue()
-              assertThat(
-                descriptorRef.declaredMemberFunctions.single { it.name == "list" }
+                descriptorRef.functions.single { it.name == "list" }
                   .returnType()
                   .isGenericType(),
               ).isTrue()
             }
             "SomeClass4" -> {
+              assertThat(psiRef.functions.single().returnType().isGenericType()).isTrue()
               assertThat(
-                psiRef.declaredMemberFunctions.single().returnType().isGenericType(),
-              ).isTrue()
-              assertThat(
-                descriptorRef.declaredMemberFunctions.single { it.name == "list" }
+                descriptorRef.functions.single { it.name == "list" }
                   .returnType()
                   .isGenericType(),
               ).isTrue()
@@ -556,228 +547,6 @@ class ClassReferenceTest : ReferenceTests {
       ),
     ) {
       assertThat(exitCode).isEqualTo(OK)
-    }
-  }
-
-  @TestFactory
-  fun `declaredMemberFunctions does not include invisible inherited functions`() = testFactory {
-
-    compile(
-      """
-      package com.squareup.test
-
-      interface Parent {
-        fun parentFunction1()
-
-        fun parentFunction2() { }
-      }
-
-      interface Child : Parent
-      """.trimIndent(),
-    ) {
-      val Child by classReferences
-
-      Child.declaredMemberFunctions.map { it.fqName.asString() } shouldBe listOf()
-    }
-  }
-
-  @TestFactory
-  fun `memberFunctions includes invisible inherited functions`() = testFactory {
-
-    compile(
-      """
-      package com.squareup.test
-
-      interface Parent {
-        fun parentFunction1()
-
-        fun parentFunction2() { }
-      }
-
-      interface Child : Parent
-      """.trimIndent(),
-    ) {
-      val Child by classReferences
-
-      Child.memberFunctions.map { it.fqName.asString() } shouldBe listOf(
-        "com.squareup.test.Parent.parentFunction1",
-        "com.squareup.test.Parent.parentFunction2",
-      )
-    }
-  }
-
-  @TestFactory
-  fun `memberFunctions does not duplicate inherited functions`() = testFactory {
-
-    compile(
-      """
-      package com.squareup.test
-
-      interface Parent {
-        fun parentFunction1()
-
-        fun parentFunction2() { }
-      }
-
-      interface Child : Parent {
-        override fun parentFunction1() { }
-      }
-      """.trimIndent(),
-    ) {
-      val Child by classReferences
-
-      Child.memberFunctions.map { it.fqName.asString() } shouldBe listOf(
-        "com.squareup.test.Child.parentFunction1",
-        "com.squareup.test.Parent.parentFunction1",
-        "com.squareup.test.Parent.parentFunction2",
-      )
-    }
-  }
-
-  @TestFactory
-  fun `declaredMemberFunctions includes overridden inherited functions`() = testFactory {
-
-    compile(
-      """
-        package com.squareup.test
-
-        interface Parent {
-          fun parentFunction1()
-
-          fun parentFunction2() { }
-        }
-
-        interface Child : Parent {
-          override fun parentFunction1() { }
-        }
-        
-        class ChildClass : Parent {
-          override fun parentFunction1() { }
-          override fun toString() = ""
-        }
-
-      """.trimIndent(),
-    ) {
-      val Child by classReferences
-      val ChildClass by classReferences
-
-      Child.declaredMemberFunctions.map { it.fqName.asString() } shouldBe listOf(
-        "com.squareup.test.Child.parentFunction1",
-      )
-      ChildClass.declaredMemberFunctions.map { it.fqName.asString() } shouldBe listOf(
-        "com.squareup.test.ChildClass.parentFunction1",
-        "com.squareup.test.ChildClass.toString",
-      )
-    }
-  }
-
-  @TestFactory
-  fun `declaredMemberProperties does not include invisible inherited properties`() = testFactory {
-
-    compile(
-      """
-      package com.squareup.test
-
-      interface Parent {
-        val parentProperty1: CharSequence
-
-        val parentProperty2: String
-      }
-
-      interface Child : Parent
-      """.trimIndent(),
-    ) {
-      val Child by classReferences
-
-      Child.declaredMemberProperties.map { it.fqName.asString() } shouldBe listOf()
-    }
-  }
-
-  @TestFactory
-  fun `memberProperties includes invisible inherited properties`() = testFactory {
-
-    compile(
-      """
-      package com.squareup.test
-
-      interface Parent {
-        val parentProperty1: CharSequence
-
-        val parentProperty2: String
-      }
-
-      interface Child : Parent
-      """.trimIndent(),
-    ) {
-      val Child by classReferences
-
-      Child.memberProperties.map { it.fqName.asString() } shouldBe listOf(
-        "com.squareup.test.Parent.parentProperty1",
-        "com.squareup.test.Parent.parentProperty2",
-      )
-    }
-  }
-
-  @TestFactory
-  fun `memberProperties does not duplicate inherited properties`() = testFactory {
-
-    compile(
-      """
-      package com.squareup.test
-
-      interface Parent {
-        val parentProperty1: CharSequence
-
-        val parentProperty2: String
-      }
-
-      interface Child : Parent {
-        override val parentProperty1: String
-      }
-      """.trimIndent(),
-    ) {
-      val Child by classReferences
-
-      Child.memberProperties.map { it.fqName.asString() } shouldBe listOf(
-        "com.squareup.test.Child.parentProperty1",
-        "com.squareup.test.Parent.parentProperty1",
-        "com.squareup.test.Parent.parentProperty2",
-      )
-    }
-  }
-
-  @TestFactory
-  fun `declaredMemberProperties includes overridden inherited properties`() = testFactory {
-
-    compile(
-      """
-        package com.squareup.test
-
-        interface Parent {
-          val parentProperty1: CharSequence
-
-          val parentProperty2: String
-        }
-
-        interface Child : Parent {
-          override val parentProperty1: String
-        }
-        
-        abstract class ChildClass : Parent {
-          abstract override val parentProperty1: String
-        }
-
-      """.trimIndent(),
-    ) {
-      val Child by classReferences
-      val ChildClass by classReferences
-
-      Child.declaredMemberProperties.map { it.fqName.asString() } shouldBe listOf(
-        "com.squareup.test.Child.parentProperty1",
-      )
-      ChildClass.declaredMemberProperties.map { it.fqName.asString() } shouldBe listOf(
-        "com.squareup.test.ChildClass.parentProperty1",
-      )
     }
   }
 }

--- a/compiler/src/test/java/com/squareup/anvil/compiler/internal/reference/MemberFunctionReferenceTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/internal/reference/MemberFunctionReferenceTest.kt
@@ -100,20 +100,21 @@ class MemberFunctionReferenceTest {
             "SomeClass1" -> {
               // Notice that the size differs between the descriptor and Psi implementation. Both
               // implementations see different values and that's expected.
-              assertThat(psiRef.functions).hasSize(0)
-              assertThat(descriptorRef.functions).hasSize(3)
-              assertThat(descriptorRef.functions.map { it.name }).containsExactly(
+              assertThat(psiRef.declaredMemberFunctions).hasSize(0)
+              assertThat(descriptorRef.declaredMemberFunctions).hasSize(3)
+              assertThat(descriptorRef.declaredMemberFunctions.map { it.name }).containsExactly(
                 "equals",
                 "toString",
                 "hashCode",
               )
             }
             "SomeClass2" -> {
-              assertThat(psiRef.functions).hasSize(1)
-              assertThat(descriptorRef.functions).hasSize(4)
+              assertThat(psiRef.declaredMemberFunctions).hasSize(1)
+              assertThat(descriptorRef.declaredMemberFunctions).hasSize(4)
 
-              val psiFunction = psiRef.functions.single()
-              val descriptorFunction = descriptorRef.functions.single { it.name == "test" }
+              val psiFunction = psiRef.declaredMemberFunctions.single()
+              val descriptorFunction =
+                descriptorRef.declaredMemberFunctions.single { it.name == "test" }
 
               assertThat(psiFunction.name).isEqualTo("test")
               assertThat(descriptorFunction.name).isEqualTo("test")
@@ -127,11 +128,12 @@ class MemberFunctionReferenceTest {
                 .isEqualTo(Unit::class.fqName)
             }
             "SomeInterface" -> {
-              assertThat(psiRef.functions).hasSize(1)
-              assertThat(descriptorRef.functions).hasSize(4)
+              assertThat(psiRef.declaredMemberFunctions).hasSize(1)
+              assertThat(descriptorRef.declaredMemberFunctions).hasSize(4)
 
-              val psiFunction = psiRef.functions.single()
-              val descriptorFunction = descriptorRef.functions.single { it.name == "test" }
+              val psiFunction = psiRef.declaredMemberFunctions.single()
+              val descriptorFunction =
+                descriptorRef.declaredMemberFunctions.single { it.name == "test" }
 
               assertThat(psiFunction.name).isEqualTo("test")
               assertThat(descriptorFunction.name).isEqualTo("test")
@@ -149,8 +151,8 @@ class MemberFunctionReferenceTest {
               assertThat(psiRef.enclosingClass()?.shortName).isEqualTo("SomeInterface")
               assertThat(descriptorRef.enclosingClass()?.shortName).isEqualTo("SomeInterface")
 
-              assertThat(psiRef.functions).hasSize(1)
-              assertThat(descriptorRef.functions).hasSize(4)
+              assertThat(psiRef.declaredMemberFunctions).hasSize(1)
+              assertThat(descriptorRef.declaredMemberFunctions).hasSize(4)
             }
             else -> throw NotImplementedError()
           }
@@ -193,8 +195,9 @@ class MemberFunctionReferenceTest {
 
           when (psiRef.shortName) {
             "SomeClass1" -> {
-              val psiFunction = psiRef.functions.single()
-              val descriptorFunction = descriptorRef.functions.single { it.name == "test" }
+              val psiFunction = psiRef.declaredMemberFunctions.single()
+              val descriptorFunction =
+                descriptorRef.declaredMemberFunctions.single { it.name == "test" }
 
               assertThat(psiFunction.returnTypeOrNull()).isNull()
               assertThat(descriptorFunction.returnType().asClassReference().fqName)
@@ -206,8 +209,9 @@ class MemberFunctionReferenceTest {
               assertThat(psiFunction.resolveGenericReturnTypeOrNull(psiRef)).isNull()
             }
             "SomeClass2", "SomeClass3" -> {
-              val psiFunction = psiRef.functions.single()
-              val descriptorFunction = descriptorRef.functions.single { it.name == "hello" }
+              val psiFunction = psiRef.declaredMemberFunctions.single()
+              val descriptorFunction =
+                descriptorRef.declaredMemberFunctions.single { it.name == "hello" }
 
               assertThat(psiFunction.returnType().asClassReference().fqName)
                 .isEqualTo(FqName("kotlin.String"))
@@ -215,8 +219,9 @@ class MemberFunctionReferenceTest {
                 .isEqualTo(FqName("kotlin.String"))
             }
             "GenericInterface1" -> {
-              val psiFunction = psiRef.functions.single()
-              val descriptorFunction = descriptorRef.functions.single { it.name == "hello" }
+              val psiFunction = psiRef.declaredMemberFunctions.single()
+              val descriptorFunction =
+                descriptorRef.declaredMemberFunctions.single { it.name == "hello" }
 
               assertThat(psiFunction.returnType().asClassReferenceOrNull()).isNull()
               assertThat(descriptorFunction.returnType().asClassReferenceOrNull()).isNull()
@@ -268,10 +273,11 @@ class MemberFunctionReferenceTest {
               ).isEqualTo(FqName("kotlin.String"))
             }
             "GenericInterface2" -> {
-              assertThat(psiRef.functions).hasSize(0)
-              assertThat(descriptorRef.functions).hasSize(4)
+              assertThat(psiRef.declaredMemberFunctions).hasSize(0)
+              assertThat(descriptorRef.declaredMemberFunctions).hasSize(4)
 
-              val descriptorFunction = descriptorRef.functions.single { it.name == "hello" }
+              val descriptorFunction =
+                descriptorRef.declaredMemberFunctions.single { it.name == "hello" }
               assertThat(descriptorFunction.returnType().asClassReferenceOrNull()).isNull()
 
               val implementingClass = FqName("com.squareup.test.SomeClass3")
@@ -325,8 +331,9 @@ class MemberFunctionReferenceTest {
 
           when (psiRef.shortName) {
             "SomeClass1", "SomeClass2" -> {
-              val psiFunction = psiRef.functions.single()
-              val descriptorFunction = descriptorRef.functions.single { it.name == "hello" }
+              val psiFunction = psiRef.declaredMemberFunctions.single()
+              val descriptorFunction =
+                descriptorRef.declaredMemberFunctions.single { it.name == "hello" }
 
               assertThat(
                 psiFunction.parameters.single().typeOrNull()
@@ -347,8 +354,9 @@ class MemberFunctionReferenceTest {
               ).isNotNull()
             }
             "GenericInterface1" -> {
-              val psiFunction = psiRef.functions.single()
-              val descriptorFunction = descriptorRef.functions.single { it.name == "hello" }
+              val psiFunction = psiRef.declaredMemberFunctions.single()
+              val descriptorFunction =
+                descriptorRef.declaredMemberFunctions.single { it.name == "hello" }
 
               assertThat(psiFunction.parameters.single().type().asClassReferenceOrNull())
                 .isNull()
@@ -398,10 +406,11 @@ class MemberFunctionReferenceTest {
               ).isNotNull()
             }
             "GenericInterface2" -> {
-              assertThat(psiRef.functions).hasSize(0)
-              assertThat(descriptorRef.functions).hasSize(4)
+              assertThat(psiRef.declaredMemberFunctions).hasSize(0)
+              assertThat(descriptorRef.declaredMemberFunctions).hasSize(4)
 
-              val descriptorFunction = descriptorRef.functions.single { it.name == "hello" }
+              val descriptorFunction =
+                descriptorRef.declaredMemberFunctions.single { it.name == "hello" }
               assertThat(
                 descriptorFunction.parameters.single().type().asClassReferenceOrNull(),
               ).isNull()

--- a/compiler/src/test/java/com/squareup/anvil/compiler/internal/reference/ReferencesTestEnvironment.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/internal/reference/ReferencesTestEnvironment.kt
@@ -79,13 +79,13 @@ class ReferencesTestEnvironment(
           ?.let { refsContainer ->
 
             val refsFun = when (referenceType) {
-              ReferenceType.Psi -> refsContainer.functions
-              ReferenceType.Descriptor -> refsContainer.toDescriptorReference().functions
+              ReferenceType.Psi -> refsContainer.declaredMemberFunctions
+              ReferenceType.Descriptor -> refsContainer.toDescriptorReference().declaredMemberFunctions
             }
               .singleOrNull { it.name == "refs" }
               ?: error {
                 "RefsContainer.refs not found.  " +
-                  "Existing functions: ${refsContainer.functions.map { it.name }}"
+                  "Existing functions: ${refsContainer.declaredMemberFunctions.map { it.name }}"
               }
 
             when (referenceType) {

--- a/sample/app/src/test/java/com/squareup/anvil/sample/UserComponentTest.kt
+++ b/sample/app/src/test/java/com/squareup/anvil/sample/UserComponentTest.kt
@@ -1,0 +1,15 @@
+package com.squareup.anvil.sample
+
+import org.junit.Test
+
+class UserComponentTest {
+
+  @Test fun `UserComponent is generated`() {
+    val parent = DaggerAppComponent.create() as UserComponent.Parent
+    val baseComponent = parent.user().create()
+    val userComponent = baseComponent as UserComponent
+
+    assert(baseComponent.description() == UserDescriptionModule.provideDescription())
+    assert(userComponent.username() == UserDescriptionModule.provideName())
+  }
+}

--- a/sample/library/src/main/java/com/squareup/anvil/sample/UserComponent.kt
+++ b/sample/library/src/main/java/com/squareup/anvil/sample/UserComponent.kt
@@ -1,0 +1,47 @@
+package com.squareup.anvil.sample
+
+import com.squareup.anvil.annotations.ContributesSubcomponent
+import com.squareup.anvil.annotations.ContributesTo
+import com.squareup.scopes.AppScope
+import com.squareup.scopes.UserScope
+import dagger.Module
+import dagger.Provides
+import javax.inject.Named
+
+interface UserDescriptionProvider {
+  @Named("userDesc")
+  fun description(): String
+}
+
+@ContributesTo(UserScope::class)
+@Module
+object UserDescriptionModule {
+
+  @Named("userName")
+  @Provides
+  fun provideName(): String = "Anvil User"
+
+  @Named("userDesc")
+  @Provides
+  fun provideDescription(): String = "User description"
+}
+
+@ContributesSubcomponent(
+  scope = UserScope::class,
+  parentScope = AppScope::class,
+)
+interface UserComponent : UserDescriptionProvider {
+
+  @Named("userName")
+  fun username(): String
+
+  @ContributesSubcomponent.Factory
+  interface Factory {
+    fun create(): UserDescriptionProvider
+  }
+
+  @ContributesTo(AppScope::class)
+  interface Parent {
+    fun user(): Factory
+  }
+}

--- a/sample/scopes/src/main/java/com/squareup/scopes/AppScope.kt
+++ b/sample/scopes/src/main/java/com/squareup/scopes/AppScope.kt
@@ -1,3 +1,5 @@
 package com.squareup.scopes
 
 abstract class AppScope private constructor()
+
+abstract class UserScope private constructor()


### PR DESCRIPTION
> [!NOTE]
> The original PR is in here: https://github.com/square/anvil/pull/1070
> But since we're using the KSP fork, we also create this PR.

This PR enables the `ContributesSubcomponent.Factory` to return the component super type.
The capability of returning component super type is available in `@MergeComponent` and is also supported in Dagger. 

An example of this can be super useful is when we have a base factory.

```kotlin
interface BaseSubcomponent {
  interface Factory {
    fun createFactory(): BaseSubcomponent
  }
}

@ContributesSubcomponent.Factory 
interface Factory : BaseSubcomponent.Factory
```
