### PR TITLE
Create a test case to reproduce the typealias lambda issue in KSP2

### DIFF
--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/AssistedFactoryGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/AssistedFactoryGeneratorTest.kt
@@ -303,6 +303,54 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
     }
   }
 
+  @Test fun `the factory function may require a typealias lambda`() {
+    compile(
+      """
+      package com.squareup.test
+      
+      import dagger.assisted.Assisted
+      import dagger.assisted.AssistedFactory
+      import dagger.assisted.AssistedInject
+      
+      typealias Foo = (Int) -> String
+
+      data class AssistedService @AssistedInject constructor(
+        val int: Int,
+        @Assisted val foo: Foo
+      )
+      
+      @AssistedFactory
+      interface AssistedServiceFactory {
+        fun create(foo: Foo): AssistedService
+      }
+      """,
+    ) {
+      val factoryImplClass = assistedServiceFactory.implClass()
+      val generatedFactoryInstance = assistedService.factoryClass().createInstance(Provider { 5 })
+      val factoryImplInstance = factoryImplClass.createInstance(generatedFactoryInstance)
+
+      val staticMethods = factoryImplClass.declaredMethods.filter { it.isStatic }
+      assertThat(staticMethods).hasSize(2)
+
+      val factoryProvider = staticMethods.single { it.name == "create" }
+        .invoke(null, generatedFactoryInstance) as Provider<*>
+      assertThat(factoryProvider.get()::class.java).isEqualTo(factoryImplClass)
+
+      val newFactoryProvider = staticMethods.single { it.name == "createFactoryProvider" }
+        .invoke(null, generatedFactoryInstance) as dagger.internal.Provider<*>
+      assertThat(newFactoryProvider.get()::class.java).isEqualTo(factoryImplClass)
+
+      val lambdaArg = { num: Int -> num.toString() }
+
+      val assistedServiceInstance = factoryImplClass.declaredMethods
+        .filterNot { it.isStatic }
+        .last { it.name == "create" }
+        .invoke(factoryImplInstance, lambdaArg)
+
+      assertThat(assistedServiceInstance).isEqualTo(assistedService.createInstance(5, lambdaArg))
+    }
+  }
+
   @Test fun `the factory function may require a lambda type`() {
     compile(
       """


### PR DESCRIPTION
Based on [the section in FORK.md](https://github.com/ZacSweers/anvil/blob/main/FORK.md#using-anvil-ksp-with-ksp2), we're trying out KSP2 with Dagger kapt, and we ran into this error:

> e: [ksp] The parameters in the factory method must match the @Assisted parameters in com.bandlab.playlist.views.CollectionPlayerViewModel.

It's caused by typealias, attaching the code snippet
```kotlin
class CollectionPlayerViewModel @AssistedInject constructor(
    @Assisted private val onCollectionPlayClickListener: OnCollectionPlayClickListener?,
) {
    // ...
    
    @AssistedFactory
    interface Factory {
        fun create(
            // ...
            onCollectionPlayClickListener: OnCollectionPlayClickListener? = null
        ): CollectionPlayerViewModel
    }
}

typealias OnCollectionPlayClickListener = () -> Unit
```

I'm not sure where the issue resides, it's either on the KSP side or Anvil, but I couldn't find a relevant issue about typealias in KSP repo. I went through the `AssistedFactoryGeneratorTest`, and I didn't see any test cases related to typealias parameter, so I added one test case. Although it's passing currently, I think maybe it's still worth having it for https://github.com/ZacSweers/anvil/issues/22?